### PR TITLE
[MUI-48] Tag and TagGroup components

### DIFF
--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { Tag } from "./Tag";
+
+export default {
+  title: "Components/Tag",
+  component: Tag,
+  args: {
+    value: "Tag Content",
+    variant: "default",
+    color: "default",
+  },
+} as ComponentMeta<typeof Tag>;
+
+const Template: ComponentStory<typeof Tag> = (args) => <Tag {...args} />;
+
+export const Default = Template.bind({});

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -18,16 +18,17 @@ export interface TagProps {
   value: string;
   /** Variant of the colour. You can set `Light` variant if
    * you want a washed out variant of the color. */
-  variant: Variants;
+  variant?: Variants;
   /** Color of the component. It supports default neutral color,
    * primary color and status colours (warning, info, etc…). */
-  color: Colors;
+  color?: Colors;
   tagRef?: React.Ref<HTMLButtonElement>;
 }
 
 /* Transform HTML component into MUI Styled Component
 in order to accept `sx` prop */
 const StyledTag = styled("span")({
+  display: "inline-block",
   fontSize: pxToRem(14),
   fontWeight: 600,
   letterSpacing: 0.5,

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { styled } from "@mui/system";
+import { alpha } from "@mui/material/styles";
+
+import { theme, pxToRem } from "@theme";
+
+export type Variants = "default" | "light";
+export type Colors =
+  | "default"
+  | "primary"
+  | "warning"
+  | "error"
+  | "info"
+  | "success";
+
+export interface TagProps {
+  /** Content of the component */
+  value: string;
+  /** Variant of the colour. You can set `Light` variant if
+   * you want a washed out variant of the color. */
+  variant: Variants;
+  /** Color of the component. It supports default neutral color,
+   * primary color and status colours (warning, info, etc…). */
+  color: Colors;
+  tagRef?: React.Ref<HTMLButtonElement>;
+}
+
+/* Transform HTML component into MUI Styled Component
+in order to accept `sx` prop */
+const StyledTag = styled("span")({
+  fontSize: pxToRem(14),
+  fontWeight: 600,
+  letterSpacing: 0.5,
+});
+
+export const Tag = ({
+  value,
+  color = "default",
+  variant = "default",
+  tagRef,
+  ...rest
+}: TagProps): JSX.Element => {
+  const tagNeutralBg =
+    variant === "light" ? theme.palette.grey[100] : theme.palette.grey[200];
+  const tagBgColor =
+    color !== "default"
+      ? variant === "light"
+        ? alpha(theme.palette[color].main, 0.1)
+        : theme.palette[color].main
+      : tagNeutralBg;
+
+  const tagTextColor =
+    variant === "default" && color === "primary"
+      ? theme.palette.primary.contrastText
+      : theme.palette.text.primary;
+
+  return (
+    <StyledTag
+      sx={{
+        py: 0.5,
+        px: 0.75,
+        backgroundColor: tagBgColor,
+        color: tagTextColor,
+        fontFamily: theme.typography.fontFamily,
+        borderRadius: theme.spacing(0.5),
+      }}
+      ref={tagRef}
+      {...rest}
+    >
+      {value}
+    </StyledTag>
+  );
+};

--- a/src/components/Tag/index.ts
+++ b/src/components/Tag/index.ts
@@ -1,0 +1,1 @@
+export * from "./Tag";

--- a/src/components/TagGroup/TagGroup.stories.tsx
+++ b/src/components/TagGroup/TagGroup.stories.tsx
@@ -1,0 +1,32 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+// Components
+import { Tag } from "@components/Tag";
+import { TagGroup } from "./TagGroup";
+
+const groupLabels: Array<string> = [
+  "Pagamenti",
+  "Udienze",
+  "Riscossione",
+  "Anagrafe",
+  "Lorem Ipsum",
+  "Dolor",
+  "Sit amet",
+  "Consectetur",
+];
+
+export default {
+  title: "Components/Tag Group",
+  component: TagGroup,
+  args: {
+    visibleItems: 4,
+  },
+} as ComponentMeta<typeof TagGroup>;
+
+export const Default: ComponentStory<typeof TagGroup> = (args) => (
+  <TagGroup {...args}>
+    {groupLabels.map((item: string, i: number) => (
+      <Tag key={`${i}-${item}`} value={item} />
+    ))}
+  </TagGroup>
+);

--- a/src/components/TagGroup/TagGroup.tsx
+++ b/src/components/TagGroup/TagGroup.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+// Components
+import { Stack } from "@mui/material";
+import { Tag } from "@components/Tag";
+
+export interface TagGroupProps {
+  children: JSX.Element | Array<JSX.Element>;
+  visibleItems: number;
+  tagRef?: React.Ref<HTMLButtonElement>;
+}
+
+export const TagGroup = ({
+  children,
+  visibleItems = NaN,
+}: TagGroupProps): JSX.Element => (
+  <Stack
+    spacing={0.5}
+    direction="row"
+    justifyContent="flex-start"
+    alignItems="flex-start"
+    sx={(theme) => ({
+      flexWrap: "wrap",
+      mt: -0.5,
+      ml: -0.5,
+      "& > *": { marginTop: `${theme.spacing(0.5)} !important`, ml: 0.5 },
+    })}
+  >
+    {/* If visibleItems is not set, show all children items.
+    If set, just show the first [n] children items */}
+    {visibleItems
+      ? React.Children.map(children, (child, i) =>
+          i < visibleItems
+            ? child
+            : visibleItems === i && (
+                <Tag value={`+${React.Children.count(children) - i}`} />
+              )
+        )
+      : children}
+  </Stack>
+);

--- a/src/components/TagGroup/index.ts
+++ b/src/components/TagGroup/index.ts
@@ -1,0 +1,1 @@
+export * from "./TagGroup";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./ButtonNaked";
 export * from "./TimelineNotification";
+export * from "./Tag";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./ButtonNaked";
 export * from "./TimelineNotification";
 export * from "./Tag";
+export * from "./TagGroup";


### PR DESCRIPTION
## List of changes in this pull request

- Add the new `Tag` component with two different variants: `default` and `light`
- Add the new `TagGroup` component with `visibleItems` prop to limit the number of visible items
- Add story to both components

#### Component preview
<img width="128" alt="Tag" src="https://user-images.githubusercontent.com/1255491/157852931-3083c67d-640b-43b8-9a77-1c4d7ce21839.png">
<img width="273" alt="Screenshot 2022-03-11 at 15 55 36" src="https://user-images.githubusercontent.com/1255491/157891626-12858645-acb5-44fd-8430-c35719d40894.png">

