### PR TITLE
[MUI-29] Menu Item

### DIFF
--- a/src/stories/Menu.stories.tsx
+++ b/src/stories/Menu.stories.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import {
+  Menu,
+  MenuItem,
+  Button,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+
+import AddCircleRoundedIcon from "@mui/icons-material/AddCircleRounded";
+
+/* Icons */
+
+export default {
+  title: "MUI Components/Navigation/Menu",
+  component: Menu,
+} as ComponentMeta<typeof Menu>;
+
+export const Default: ComponentStory<typeof Menu> = () => {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        id="basic-button"
+        aria-controls={open ? "basic-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={handleClick}
+      >
+        Action Menu
+      </Button>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          "aria-labelledby": "basic-button",
+        }}
+      >
+        <MenuItem onClick={handleClose}>A very looooong item</MenuItem>
+        <MenuItem onClick={handleClose}>A normal one</MenuItem>
+        <MenuItem onClick={handleClose}>Short</MenuItem>
+        <MenuItem onClick={handleClose}>
+          <ListItemIcon>
+            <AddCircleRoundedIcon fontSize="inherit" />
+          </ListItemIcon>
+          <ListItemText>With icon</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+};
+
+Default.parameters = {
+  controls: { hideNoControlsWarning: true },
+};

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -58,13 +58,19 @@ export const Default: ComponentStory<typeof FormControl> = (args) => {
           label="Cerca per:"
           onChange={handleChange}
         >
-          <MenuItem value={"it-fiscal-code"}>
+          <MenuItem selected value={"it-health-code"}>
+            Tessera Sanitaria
+          </MenuItem>
+          <MenuItem selected value={"it-fiscal-code"}>
             <ListItemIcon>
-              <SubtitlesRoundedIcon />
+              <SubtitlesRoundedIcon fontSize="inherit" />
             </ListItemIcon>
             <ListItemText>Codice fiscale</ListItemText>
           </MenuItem>
           <MenuItem value={"IUN"}>Codice IUN</MenuItem>
+          <MenuItem disabled value={"Deprecated Code"}>
+            Disabled field
+          </MenuItem>
         </Select>
       </FormControl>
     </Box>

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -702,6 +702,9 @@ export const theme = createTheme(foundation, {
         root: {
           backgroundColor: alpha(backdropBackground, 0.7),
         },
+        invisible: {
+          backgroundColor: "transparent",
+        },
       },
     },
     MuiTimelineDot: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -766,7 +766,15 @@ export const theme = createTheme(foundation, {
       },
     },
     /** End LIST ITEM */
-    /** Start SELECT */
+    /** Start POPOVER */
+    MuiPopover: {
+      styleOverrides: {
+        paper: {
+          boxShadow: foundation.shadows[16],
+        },
+      },
+    },
+    /** End POPOVER */
     MuiMenuItem: {
       defaultProps: {
         disableRipple: true,

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -25,6 +25,7 @@ const responsiveBreakpoint = "sm";
 const ringWidth = "4px";
 const alertBorderWidth = "4px";
 const backdropBackground = "#17324D";
+const menuItemBackground = "#17324D";
 const shadowColor = "#002B55";
 
 const shadowValues = {
@@ -778,6 +779,19 @@ export const theme = createTheme(foundation, {
       },
     },
     /** End POPOVER */
+    MuiSelect: {
+      styleOverrides: {
+        root: {
+          "& .MuiListItemIcon-root + .MuiListItemText-root": {
+            marginLeft: foundation.spacing(1),
+          },
+        },
+        select: {
+          display: "flex",
+          alignItems: "center",
+        },
+      },
+    },
     MuiMenuItem: {
       defaultProps: {
         disableRipple: true,
@@ -785,6 +799,32 @@ export const theme = createTheme(foundation, {
       styleOverrides: {
         root: {
           fontWeight: 600,
+          "& .MuiListItemIcon-root": {
+            color: foundation.palette.action.active,
+            fontSize: pxToRem(20),
+            minWidth: "auto",
+          },
+          "& .MuiListItemIcon-root + .MuiListItemText-root": {
+            marginLeft: foundation.spacing(1),
+          },
+          /* I know that the CSS overwrite under this block don't look very nice ¯\_(ツ)_/¯
+          But it seems the only way to style these elements without building
+          everything from the ground using Unstyled components */
+          "& .MuiListItemText-root .MuiListItemText-primary": {
+            fontSize: pxToRem(16),
+          },
+          "&.Mui-selected": {
+            color: foundation.palette.primary.main,
+            ".MuiListItemText-root": {
+              color: foundation.palette.primary.main,
+            },
+            ".MuiListItemIcon-root": {
+              color: foundation.palette.primary.main,
+            },
+          },
+          "&:hover": {
+            backgroundColor: alpha(menuItemBackground, 0.04),
+          },
         },
       },
     },


### PR DESCRIPTION
## List of changes in this pull request

- Add theme overrides to the `MenuItem` component, fix style when there are both icon and text
- Add correct shadow to the `Popover` component 
- Add `Menu` story to the Storybook
- Fix ubiquitous backdrop in Select or Menu components when state is set to `open`

#### Component Preview
<img width="250" alt="Screenshot 2022-03-18 at 17 34 33" src="https://user-images.githubusercontent.com/1255491/159044435-bda72191-62aa-4efc-8901-18a805df96c7.png">

