### PR TITLE
[MUI-62] Styled `Snackbar`

### DIFF
--- a/src/stories/Snackbar.stories.tsx
+++ b/src/stories/Snackbar.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Snackbar, Stack, IconButton, Button, Alert } from "@mui/material";
+import { Snackbar, IconButton, Button, Alert } from "@mui/material";
 
 /* Icons */
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
@@ -19,7 +19,7 @@ export const Default: ComponentStory<typeof Snackbar> = () => {
   };
 
   const handleClose = (
-    event: React.SyntheticEvent | Event,
+    _event: React.SyntheticEvent | Event,
     reason?: string
   ) => {
     if (reason === "clickaway") {
@@ -48,7 +48,7 @@ export const Default: ComponentStory<typeof Snackbar> = () => {
   return (
     <div>
       <Button variant="contained" onClick={handleClick}>
-        Open simple snackbar
+        Open snackbar
       </Button>
       <Snackbar
         open={open}
@@ -72,7 +72,7 @@ export const WithStatus: ComponentStory<typeof Alert> = (args) => {
   };
 
   const handleClose = (
-    event?: React.SyntheticEvent | Event,
+    _event?: React.SyntheticEvent | Event,
     reason?: string
   ) => {
     if (reason === "clickaway") {
@@ -84,7 +84,7 @@ export const WithStatus: ComponentStory<typeof Alert> = (args) => {
   return (
     <div>
       <Button variant="contained" onClick={handleClick}>
-        Open toast notification
+        Open snackbar
       </Button>
       <Snackbar open={open} onClose={handleClose}>
         <Alert
@@ -93,7 +93,7 @@ export const WithStatus: ComponentStory<typeof Alert> = (args) => {
           sx={{ width: "100%" }}
           {...args}
         >
-          An importante message you should read
+          An important message you should read
         </Alert>
       </Snackbar>
     </div>

--- a/src/stories/Snackbar.stories.tsx
+++ b/src/stories/Snackbar.stories.tsx
@@ -53,7 +53,7 @@ export const Default: ComponentStory<typeof Snackbar> = () => {
       <Snackbar
         open={open}
         onClose={handleClose}
-        message="Note archived"
+        message="Important message"
         action={action}
       />
     </div>

--- a/src/stories/Snackbar.stories.tsx
+++ b/src/stories/Snackbar.stories.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { Snackbar, Stack, IconButton, Button, Alert } from "@mui/material";
+
+/* Icons */
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+
+export default {
+  title: "MUI Components/Feedback/Snackbar",
+  component: Snackbar,
+} as ComponentMeta<typeof Snackbar>;
+
+export const Default: ComponentStory<typeof Snackbar> = () => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClick = () => {
+    setOpen(true);
+  };
+
+  const handleClose = (
+    event: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  const action = (
+    <React.Fragment>
+      <Button size="small" variant="text">
+        Action
+      </Button>
+      <IconButton
+        size="small"
+        aria-label="close"
+        color="inherit"
+        onClick={handleClose}
+      >
+        <CloseRoundedIcon fontSize="small" />
+      </IconButton>
+    </React.Fragment>
+  );
+
+  return (
+    <div>
+      <Button variant="contained" onClick={handleClick}>
+        Open simple snackbar
+      </Button>
+      <Snackbar
+        open={open}
+        onClose={handleClose}
+        message="Note archived"
+        action={action}
+      />
+    </div>
+  );
+};
+
+Default.parameters = {
+  controls: { hideNoControlsWarning: true },
+};
+
+export const WithStatus: ComponentStory<typeof Alert> = (args) => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClick = () => {
+    setOpen(true);
+  };
+
+  const handleClose = (
+    event?: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+
+    setOpen(false);
+  };
+  return (
+    <div>
+      <Button variant="contained" onClick={handleClick}>
+        Open toast notification
+      </Button>
+      <Snackbar open={open} onClose={handleClose}>
+        <Alert
+          onClose={handleClose}
+          variant="outlined"
+          sx={{ width: "100%" }}
+          {...args}
+        >
+          An importante message you should read
+        </Alert>
+      </Snackbar>
+    </div>
+  );
+};
+
+WithStatus.argTypes = {
+  severity: {
+    options: ["error", "warning", "info", "success"],
+    control: { type: "radio" },
+    table: {
+      type: { summary: "string" },
+    },
+  },
+};
+
+WithStatus.args = {
+  severity: "success",
+};

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -491,6 +491,7 @@ export const theme = createTheme(foundation, {
         outlined: {
           backgroundColor: foundation.palette.common.white,
           boxShadow: foundation.shadows[4],
+          borderWidth: `0 0 0 ${alertBorderWidth}`,
         },
         standard: {
           "& .MuiAlert-icon": {
@@ -550,6 +551,25 @@ export const theme = createTheme(foundation, {
       },
     },
     /* END Alert */
+    /* START Snackbar */
+    MuiSnackbarContent: {
+      styleOverrides: {
+        root: {
+          padding: foundation.spacing(2),
+          color: foundation.palette.text.primary,
+          backgroundColor: foundation.palette.common.white,
+          boxShadow: foundation.shadows[4],
+        },
+        action: {
+          marginRight: 0,
+        },
+        message: {
+          padding: 0,
+          fontSize: pxToRem(16),
+        },
+      },
+    },
+    /* END Snackbar */
     MuiBadge: {
       styleOverrides: {
         badge: {


### PR DESCRIPTION
## List of changes in this pull request

- Add theme overrides to the `Snackbar` and `SnackbarContent` components
- Add relative stories to the Storybook

#### Component Preview
<img width="372" alt="Screenshot 2022-03-21 at 14 32 06" src="https://user-images.githubusercontent.com/1255491/159271558-4078f43f-6d16-4f41-95ae-c1e963b89711.png">

