### PR TITLE
MUI 144 – Split <Hero> component into text and text+image variants

### DIFF
--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -32,12 +32,10 @@ export default {
     subtitle:
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc eget lacus consequat, accumsan metus sed, pharetra dui. Praesent at accumsan odio. Praesent augue ipsum, pharetra eget metus vel, bibendum dapibus augue. Nunc maximus id eros finibus laoreet. Integer iaculis, neque at feugiat accumsan, nisi magna iaculis nisl, ultricies euismod nulla orci sit amet justo.",
     inverse: false,
-    image: heroImage,
     background: heroBackground,
     showPrimary: true,
     ctaPrimary: firstCTA,
     ctaSecondary: secondCTA,
-    altText: "altText",
   },
   argTypes: {
     inverse: {
@@ -48,9 +46,32 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    type: {
+      table: {
+        disable: true,
+      },
+    },
   },
 } as ComponentMeta<typeof Hero>;
 
-export const Default: ComponentStory<typeof Hero> = (args) => (
+export const WithImage: ComponentStory<typeof Hero> = (args) => (
   <Hero {...args} />
 );
+export const WithImageProps = WithImage.bind({});
+WithImage.args = {
+  type: "image",
+  image: heroImage,
+  altText: "altText",
+};
+
+export const JustText: ComponentStory<typeof Hero> = (args) => (
+  <Hero {...args} />
+);
+export const JustTextProps = JustText.bind({});
+JustText.args = {
+  type: "text",
+};
+JustText.argTypes = {
+  image: { table: { disable: true } },
+  altText: { table: { disable: true } },
+};

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -13,11 +13,11 @@ interface HeroBasicProps extends HeroTextProps {
   background?: string;
 }
 
-export interface HeroJustTextProps extends HeroBasicProps {
+interface HeroJustTextProps extends HeroBasicProps {
   type: "text";
 }
 
-export interface HeroWithImageProps extends HeroBasicProps {
+interface HeroWithImageProps extends HeroBasicProps {
   type: "image";
   image: string;
   altText: string;

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,133 +1,163 @@
 import { Box, Button, Stack, Typography, Container } from "@mui/material";
 import { CTA } from "@types";
 
-export interface HeroProps {
+interface HeroTextProps {
   title: string;
   subtitle?: string | JSX.Element;
   ctaPrimary?: CTA;
   ctaSecondary?: CTA;
+}
+
+interface HeroBasicProps extends HeroTextProps {
   inverse?: boolean;
-  image?: string;
-  altText?: string;
   background?: string;
 }
 
-export const Hero = ({
+export interface HeroJustTextProps extends HeroBasicProps {
+  type: "text";
+}
+
+export interface HeroWithImageProps extends HeroBasicProps {
+  type: "image";
+  image: string;
+  altText: string;
+}
+
+export type HeroProps = HeroJustTextProps | HeroWithImageProps;
+
+const HERO_TEXT_PADDING = { xs: 4, sm: 4, md: 8 };
+
+const HeroTextContent = ({
   title,
   subtitle,
   ctaPrimary,
   ctaSecondary,
-  inverse = false,
+}: HeroTextProps) => (
+  <Stack spacing={4}>
+    <Stack spacing={2}>
+      <Typography variant="h1" color="primary.contrastText">
+        {title}
+      </Typography>
+      <>
+        {subtitle && typeof subtitle === "string" && (
+          <Typography variant="body1" color="primary.contrastText">
+            {subtitle}
+          </Typography>
+        )}
+        {subtitle && typeof subtitle !== "string" && subtitle}
+      </>
+    </Stack>
+    <Stack direction="row" spacing={2}>
+      {ctaPrimary && (
+        <Box>
+          <Button
+            aria-label={ctaPrimary.title}
+            variant="contained"
+            color="negative"
+            onClick={ctaPrimary.onClick}
+            component="a"
+          >
+            {ctaPrimary.label}
+          </Button>
+        </Box>
+      )}
+      {ctaSecondary && (
+        <Box>
+          <Button
+            aria-label={ctaSecondary.title}
+            color="negative"
+            variant="outlined"
+            onClick={ctaSecondary.onClick}
+            component="a"
+          >
+            {ctaSecondary.label}
+          </Button>
+        </Box>
+      )}
+    </Stack>
+  </Stack>
+);
+
+const HeroJustText = (props: HeroJustTextProps) => (
+  <Box sx={{ maxWidth: "40rem", margin: "0 auto", py: HERO_TEXT_PADDING }}>
+    <HeroTextContent {...props} />
+  </Box>
+);
+
+const HeroWithImage = ({
+  inverse,
   image,
   altText = "Hero Image",
-  background,
-}: HeroProps) => (
+  ...props
+}: HeroWithImageProps) => (
+  <>
+    <Box
+      sx={{
+        display: "grid",
+        columnGap: 3,
+        rowGap: 5,
+        gridTemplateColumns: {
+          xs: "repeat(6, minmax(0, 1fr))",
+          md: "repeat(12, minmax(0, 1fr))",
+        },
+        py: HERO_TEXT_PADDING,
+      }}
+    >
+      <Box
+        gridColumn={{
+          xs: "span 6",
+          md: inverse ? "7 / span 5" : "2 / span 5",
+        }}
+        gridRow={{
+          xs: "auto",
+          md: 1,
+        }}
+        my="auto"
+      >
+        <HeroTextContent {...props} />
+      </Box>
+      <Box
+        gridColumn={{
+          xs: "span 6",
+          md: inverse ? "2 / span 5" : "7 / span 5",
+        }}
+        gridRow={{
+          xs: "auto",
+          md: 1,
+        }}
+        alignSelf="center"
+      >
+        <img
+          alt={altText}
+          src={image}
+          style={{
+            objectFit: "contain",
+            objectPosition: "center",
+            width: "100%",
+            height: "100%",
+            maxHeight: "600px",
+            userSelect: "none",
+          }}
+        />
+      </Box>
+    </Box>
+  </>
+);
+
+export const Hero = (props: HeroProps) => (
   <Box
     bgcolor="primary.main"
     sx={{
-      backgroundImage: `url(${background})`,
+      backgroundImage: `url(${props.background})`,
       backgroundSize: "cover",
     }}
   >
     <Container maxWidth="xl">
-      <Box
-        sx={{
-          display: "grid",
-          columnGap: 3,
-          rowGap: 5,
-          gridTemplateColumns: {
-            xs: "repeat(6, minmax(0, 1fr))",
-            md: "repeat(12, minmax(0, 1fr))",
-          },
-          py: {
-            xs: 4,
-            sm: 4,
-            md: 8,
-          },
-        }}
-      >
-        <Box
-          gridColumn={{
-            xs: "span 6",
-            md: inverse ? "7 / span 5" : "2 / span 5",
-          }}
-          gridRow={{
-            xs: "auto",
-            md: 1,
-          }}
-          my="auto"
-        >
-          <Stack spacing={4}>
-            <Stack spacing={2}>
-              <Typography variant="h1" color="primary.contrastText">
-                {title}
-              </Typography>
-              <>
-                {subtitle && typeof subtitle === "string" && (
-                  <Typography variant="body1" color="primary.contrastText">
-                    {subtitle}
-                  </Typography>
-                )}
-                {subtitle && typeof subtitle !== "string" && subtitle}
-              </>
-            </Stack>
-            <Stack direction="row" spacing={2}>
-              {ctaPrimary && (
-                <Box>
-                  <Button
-                    aria-label={ctaPrimary.title}
-                    variant="contained"
-                    color="negative"
-                    onClick={ctaPrimary.onClick}
-                    component="a"
-                  >
-                    {ctaPrimary.label}
-                  </Button>
-                </Box>
-              )}
-              {ctaSecondary && (
-                <Box>
-                  <Button
-                    aria-label={ctaSecondary.title}
-                    color="negative"
-                    variant="outlined"
-                    onClick={ctaSecondary.onClick}
-                    component="a"
-                  >
-                    {ctaSecondary.label}
-                  </Button>
-                </Box>
-              )}
-            </Stack>
-          </Stack>
-        </Box>
-        <Box
-          gridColumn={{
-            xs: "span 6",
-            md: inverse ? "2 / span 5" : "7 / span 5",
-          }}
-          gridRow={{
-            xs: "auto",
-            md: 1,
-          }}
-          alignSelf="center"
-        >
-          {image && (
-            <img
-              alt={altText}
-              src={image}
-              style={{
-                objectFit: "contain",
-                objectPosition: "center",
-                width: "100%",
-                height: "100%",
-                maxHeight: "600px",
-                userSelect: "none",
-              }}
-            />
-          )}
-        </Box>
-      </Box>
+      {props.type === "image" ? (
+        <HeroWithImage {...props} />
+      ) : (
+        <HeroJustText {...props} />
+      )}
     </Container>
   </Box>
 );


### PR DESCRIPTION
## :rotating_light: **This PR contains a breaking change** 
There is now a required `type` prop, needed to produce a Typescript discriminated union. Set it to `text` if the hero has no image and to `image` if there is.

## Result
### type = "image"
| Desktop  | Mobile |
| ------------- | ------------- |
| ![Screenshot 2022-08-17 at 15 21 15](https://user-images.githubusercontent.com/6032099/185144905-3dbee637-f039-4752-b9f0-11f3415145b8.png) | <img width="628" alt="Screenshot 2022-08-17 at 15 21 44" src="https://user-images.githubusercontent.com/6032099/185144998-f7b0430c-c74f-44c4-9317-aee1f3e5bb67.png"> |

### type = "text"
| Desktop  | Mobile |
| ------------- | ------------- |
| <img width="1771" alt="Screenshot 2022-08-17 at 15 21 24" src="https://user-images.githubusercontent.com/6032099/185145142-de1766d2-5573-46ad-bef8-003149c686b0.png"> | <img width="628" alt="Screenshot 2022-08-17 at 15 21 30" src="https://user-images.githubusercontent.com/6032099/185145207-6cd965f9-7c22-4c1b-85bf-0e472c94d834.png"> |

## Storybook edits
Since Storybook doesn't infer types correctly on discriminated unions, there is additional work in the `Hero.stories.tsx` file to hide the args that are not relevant. The result is that `type="image"` has additional controls (see screenshot below)
<img width="1784" alt="Screenshot 2022-08-17 at 15 19 41" src="https://user-images.githubusercontent.com/6032099/185144452-20a8e960-4cc9-4f4b-bd5f-e6d9d3a25789.png">

