### PR TITLE
[MUI-162] Remove dynamic value(s) from Storybook

### DIFF
--- a/src/stories/DesktopDatePicker.stories.tsx
+++ b/src/stories/DesktopDatePicker.stories.tsx
@@ -23,7 +23,7 @@ export default {
 } as ComponentMeta<typeof DesktopDatePicker>;
 
 export const Default: ComponentStory<typeof DesktopDatePicker> = () => {
-  const [value, setValue] = useState<Date>(new Date());
+  const [value, setValue] = useState<Date>(new Date(2022, 0, 17));
 
   const onChangeHandler = (_date: Date | null) => {
     if (_date) {


### PR DESCRIPTION
## Short description
This PR remove the dynamic date value from the `DesktopDatePicker` story. The dynamic value generates a snapshot's change in Chromatic that requires a manual approval from the maintainer. This PR removes this annoyance.

## List of changes proposed in this pull request
- Update the `Date()` parameter with a fixed value