### PR TITLE
MUI-165 - Fixed wrong import 

### DIFF
--- a/src/components/HorizontalNav/HorizontalNav.tsx
+++ b/src/components/HorizontalNav/HorizontalNav.tsx
@@ -6,7 +6,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { ArrowForward } from "@mui/icons-material";
+import ArrowForward from "@mui/icons-material/ArrowForward";
 
 interface sectionCTA {
   label: string;


### PR DESCRIPTION
This PR fixes the wrong import to the `@mui/icons-material` package that brought an increase of the bundle size by ~4MB.

Before all `@mui/icons-material` was included in the bundle:
![image](https://user-images.githubusercontent.com/62668966/196137845-755ea123-61bd-4e5f-8503-02a7b8b9b14b.png)


After: 
<img width="1657" alt="Schermata 2022-10-17 alle 11 10 31" src="https://user-images.githubusercontent.com/62668966/196138189-859374d8-bf91-4471-90c1-ec712750a2e0.png">
