### PR TITLE
[MUI-166] Add viewport values to Chromatic

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -100,14 +100,13 @@ export const globalTypes = {
     toolbar: {
       // The icon for the toolbar item
       icon: "circlehollow",
+      title: "Theme",
       // Array of options
       items: [
         { value: "system", icon: "cog", title: "System" },
         { value: "light", icon: "circlehollow", title: "Light" },
         { value: "dark", icon: "circle", title: "Dark" },
       ],
-      // Property that specifies if the name of the item will be displayed
-      showName: true,
     },
   },
 };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -12,6 +12,7 @@ import { theme as lightTheme, darkTheme } from "@theme";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
+  layout: "fullscreen",
   controls: {
     expanded: true,
     matchers: {
@@ -31,12 +32,6 @@ interface StoryContainerProps {
 const StoryContainer = ({ children }: StoryContainerProps) => (
   <Box
     sx={{
-      position: "absolute",
-      inset: 0,
-      width: "100vw",
-      minHeight: "100vh",
-      overflow: "auto",
-      padding: "1rem",
       backgroundColor: "background.paper",
     }}
     data-chromatic="ignore"

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -30,12 +30,7 @@ interface StoryContainerProps {
 }
 
 const StoryContainer = ({ children }: StoryContainerProps) => (
-  <Box
-    sx={{
-      backgroundColor: "background.paper",
-    }}
-    data-chromatic="ignore"
-  >
+  <Box sx={{ backgroundColor: "background.paper" }} data-chromatic="ignore">
     {children}
   </Box>
 );

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -34,7 +34,7 @@ const StoryContainer = ({ children }: StoryContainerProps) => (
       position: "absolute",
       inset: 0,
       width: "100vw",
-      height: "100vh",
+      minHeight: "100vh",
       overflow: "auto",
       padding: "1rem",
       backgroundColor: "background.paper",

--- a/src/assets/FundedByNextGenerationEU/FundedByNextGenerationEU.stories.tsx
+++ b/src/assets/FundedByNextGenerationEU/FundedByNextGenerationEU.stories.tsx
@@ -9,6 +9,9 @@ export default {
     variant: "outline",
     color: "dark",
   },
+  parameters: {
+    layout: "centered",
+  },
 } as ComponentMeta<typeof FundedByNextGenerationEU>;
 
 const Template: ComponentStory<typeof FundedByNextGenerationEU> = (args) => (

--- a/src/assets/LogoIOApp/LogoIOApp.stories.tsx
+++ b/src/assets/LogoIOApp/LogoIOApp.stories.tsx
@@ -8,6 +8,9 @@ export default {
   args: {
     color: "dark",
   },
+  parameters: {
+    layout: "centered",
+  },
 } as ComponentMeta<typeof LogoIOApp>;
 
 const Template: ComponentStory<typeof LogoIOApp> = (args) => (

--- a/src/assets/LogoPagoPACompany/LogoPagoPACompany.stories.tsx
+++ b/src/assets/LogoPagoPACompany/LogoPagoPACompany.stories.tsx
@@ -9,6 +9,9 @@ export default {
     color: "dark",
     variant: "default",
   },
+  parameters: {
+    layout: "centered",
+  },
 } as ComponentMeta<typeof LogoPagoPACompany>;
 
 const Template: ComponentStory<typeof LogoPagoPACompany> = (args) => (

--- a/src/assets/LogoPagoPAProduct/LogoPagoPAProduct.stories.tsx
+++ b/src/assets/LogoPagoPAProduct/LogoPagoPAProduct.stories.tsx
@@ -8,6 +8,9 @@ export default {
   args: {
     color: "dark",
   },
+  parameters: {
+    layout: "centered",
+  },
 } as ComponentMeta<typeof LogoPagoPAProduct>;
 
 const Template: ComponentStory<typeof LogoPagoPAProduct> = (args) => (
@@ -18,20 +21,6 @@ export const Default = Template.bind({});
 Default.args = {
   color: "default",
 };
-/* Default.decorators = [
-  (Story) => (
-    <div
-      style={{
-        position: "fixed",
-        inset: "0",
-        display: "grid",
-        placeItems: "center",
-      }}
-    >
-      <Story />
-    </div>
-  ),
-]; */
 
 export const Negative = Template.bind({});
 Negative.args = {

--- a/src/assets/MonogramPagoPACompany/MonogramPagoPACompany.stories.tsx
+++ b/src/assets/MonogramPagoPACompany/MonogramPagoPACompany.stories.tsx
@@ -9,6 +9,9 @@ export default {
     color: "primary",
     shape: "none",
   },
+  parameters: {
+    layout: "centered",
+  },
 } as ComponentMeta<typeof MonogramPagoPACompany>;
 
 const Template: ComponentStory<typeof MonogramPagoPACompany> = (args) => (

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -23,7 +23,7 @@ export default {
   parameters: {
     controls: { hideNoControlsWarning: true },
     chromatic: {
-      viewports: [theme.breakpoints.values.xs, theme.breakpoints.values.lg],
+      viewports: [320, theme.breakpoints.values.lg],
     },
   },
   argTypes: {

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,6 +1,8 @@
 /* import { useState } from "react"; */
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { FooterCheckout } from "@components/FooterCheckout";
+import { theme } from "@theme";
+
 import {
   Footer,
   PreLoginFooterLinksType,
@@ -20,6 +22,9 @@ export default {
   ],
   parameters: {
     controls: { hideNoControlsWarning: true },
+    chromatic: {
+      viewports: [theme.breakpoints.values.xs, theme.breakpoints.values.lg],
+    },
   },
   argTypes: {
     hideProductColums: {

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,7 +1,7 @@
 /* import { useState } from "react"; */
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { FooterCheckout } from "@components/FooterCheckout";
-import { theme } from "@theme";
+import { breakpointsChromaticValues } from "@theme";
 
 import {
   Footer,
@@ -23,7 +23,7 @@ export default {
   parameters: {
     controls: { hideNoControlsWarning: true },
     chromatic: {
-      viewports: [320, theme.breakpoints.values.lg],
+      viewports: breakpointsChromaticValues,
     },
   },
   argTypes: {

--- a/src/components/HeaderAccount/HeaderAccount.stories.tsx
+++ b/src/components/HeaderAccount/HeaderAccount.stories.tsx
@@ -5,6 +5,8 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 import SettingsIcon from "@mui/icons-material/Settings";
 import LogoutRoundedIcon from "@mui/icons-material/LogoutRounded";
 
+import { breakpointsChromaticValues } from "@theme";
+
 import { HeaderAccount, RootLinkType, JwtUser } from "./HeaderAccount";
 
 export default {
@@ -19,6 +21,9 @@ export default {
   ],
   parameters: {
     controls: { hideNoControlsWarning: true },
+    chromatic: {
+      viewports: breakpointsChromaticValues,
+    },
   },
 } as ComponentMeta<typeof HeaderAccount>;
 

--- a/src/components/HeaderProduct/HeaderProduct.stories.tsx
+++ b/src/components/HeaderProduct/HeaderProduct.stories.tsx
@@ -1,5 +1,7 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
+import { breakpointsChromaticValues } from "@theme";
+
 import {
   HeaderProduct,
   PartyEntity,
@@ -18,6 +20,9 @@ export default {
   ],
   parameters: {
     controls: { hideNoControlsWarning: true },
+    chromatic: {
+      viewports: breakpointsChromaticValues,
+    },
   },
 } as ComponentMeta<typeof HeaderProduct>;
 

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { breakpointsChromaticValues } from "@theme";
+
 import { Hero } from "@components/Hero";
 
 import heroBackground from "./assets/hero_background.png";
@@ -27,6 +30,11 @@ export default {
       </div>
     ),
   ],
+  parameters: {
+    chromatic: {
+      viewports: breakpointsChromaticValues,
+    },
+  },
   args: {
     title: "Title",
     subtitle:

--- a/src/components/HorizontalNav/HorizontalNav.stories.tsx
+++ b/src/components/HorizontalNav/HorizontalNav.stories.tsx
@@ -3,6 +3,8 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { CieIcon } from "@icons/CieIcon";
 import { SpidIcon } from "@icons/SpidIcon";
 
+import { breakpointsChromaticValues } from "@theme";
+
 const sections = [
   {
     icon: <CieIcon />,
@@ -30,6 +32,11 @@ const sections = [
 export default {
   title: "Components/HorizontalNav",
   component: HorizontalNav,
+  parameters: {
+    chromatic: {
+      viewports: breakpointsChromaticValues,
+    },
+  },
   decorators: [
     (Story) => (
       <div style={{ padding: 0, backgroundColor: "#F5F5F5" }}>

--- a/src/components/Infoblock/Infoblock.stories.tsx
+++ b/src/components/Infoblock/Infoblock.stories.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { breakpointsChromaticValues } from "@theme";
+
 import { Infoblock } from "@components/Infoblock";
 
 const primaryCTA = {
@@ -17,13 +20,11 @@ const secondaryCTA = {
 export default {
   title: "Components/Infoblock",
   component: Infoblock,
-  decorators: [
-    (Story) => (
-      <div style={{ padding: 0, backgroundColor: "#FFFFFF" }}>
-        <Story />
-      </div>
-    ),
-  ],
+  parameters: {
+    chromatic: {
+      viewports: breakpointsChromaticValues,
+    },
+  },
   args: {
     overline: "Overline",
     title: "Title",

--- a/src/components/PartyAccountItem/PartyAccountItem.stories.tsx
+++ b/src/components/PartyAccountItem/PartyAccountItem.stories.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { Button, Stack } from "@mui/material";
+
+import { breakpointsChromaticValues } from "@theme";
 
 import { PartyAccountItem, PartyAccount } from "@components/PartyAccountItem";
 
@@ -118,6 +119,13 @@ export default {
       </div>
     ),
   ],
+  parameters: {
+    chromatic: {
+      viewports: breakpointsChromaticValues.filter(
+        (resolution) => resolution <= 900
+      ),
+    },
+  },
 } as ComponentMeta<typeof PartyAccountItem>;
 
 const Template: ComponentStory<typeof PartyAccountItem> = (args) => {

--- a/src/components/PartyAccountItem/PartyAccountItem.stories.tsx
+++ b/src/components/PartyAccountItem/PartyAccountItem.stories.tsx
@@ -11,6 +11,10 @@ const cdnPath = "https://assets.cdn.io.italia.it/logos/organizations/";
 
 const partyMockImages: Array<PartyAccount> = [
   {
+    image: `${cdnPath}81000410688.png`,
+    name: "Comune di San Valentino in Abruzzo Citeriore",
+  },
+  {
     image: `${cdnPath}1199250158.png`,
     name: "Comune di Milano",
     role: "Referente amministrativo",
@@ -50,10 +54,6 @@ const partyMockImages: Array<PartyAccount> = [
     name: "Comune di Pescasseroli",
   },
   {
-    image: `${cdnPath}81000410688.png`,
-    name: "Comune di San Valentino in Abruzzo Citeriore",
-  },
-  {
     image: `${cdnPath}189800204.png`,
     name: "Comune di Mantova",
     role: "Referente amministrativo",
@@ -87,6 +87,8 @@ const partyMockImages: Array<PartyAccount> = [
     role: `Operatore - Operatore API Operatore - Operatore API`,
   },
 ];
+
+const componentMaxWidth = 500;
 
 /* Generate random value without repeating values
   Source of this snippet: https://akashmittal.com/javascript-random-array-element-no-repeat/ */
@@ -122,7 +124,7 @@ export default {
   parameters: {
     chromatic: {
       viewports: breakpointsChromaticValues.filter(
-        (resolution) => resolution <= 900
+        (resolution) => resolution <= componentMaxWidth
       ),
     },
   },
@@ -138,7 +140,7 @@ const Template: ComponentStory<typeof PartyAccountItem> = (args) => {
   };
 
   return (
-    <Stack gap={2} alignItems="flex-start" sx={{ maxWidth: 350 }}>
+    <Stack gap={2} alignItems="flex-start" sx={{ maxWidth: componentMaxWidth }}>
       <Button variant="contained" onClick={getRandomParty}>
         Get random Party
       </Button>
@@ -154,6 +156,9 @@ const Template: ComponentStory<typeof PartyAccountItem> = (args) => {
 };
 
 export const Default = Template.bind({});
+Default.args = {
+  noWrap: false,
+};
 
 export const NoWrap = Template.bind({});
 NoWrap.args = {

--- a/src/components/PartyAccountItemButton/PartyAccountItemButton.stories.tsx
+++ b/src/components/PartyAccountItemButton/PartyAccountItemButton.stories.tsx
@@ -93,6 +93,8 @@ const partyMockImages: Array<PartyAccount> = [
 /* Tag Element */
 const tag: JSX.Element = <Tag color="warning" value="Da completare" />;
 
+const componentMaxWidth = 400;
+
 /* Generate random value without repeating values
   Source of this snippet: https://akashmittal.com/javascript-random-array-element-no-repeat/ */
 const alreadyPicked: Array<number> = [];
@@ -116,7 +118,7 @@ export default {
     layout: "padded",
     chromatic: {
       viewports: breakpointsChromaticValues.filter(
-        (resolution) => resolution <= 900
+        (resolution) => resolution <= componentMaxWidth
       ),
     },
   },
@@ -132,7 +134,7 @@ const Template: ComponentStory<typeof PartyAccountItemButton> = (args) => {
   };
 
   return (
-    <Stack gap={2} alignItems="flex-start" sx={{ maxWidth: 350 }}>
+    <Stack gap={2} alignItems="flex-start" sx={{ maxWidth: componentMaxWidth }}>
       <Button variant="contained" onClick={getRandomParty}>
         Get random Party
       </Button>

--- a/src/components/PartyAccountItemButton/PartyAccountItemButton.stories.tsx
+++ b/src/components/PartyAccountItemButton/PartyAccountItemButton.stories.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
-
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { Button, Stack } from "@mui/material";
 
-import { Tag } from "@components/Tag";
+import { breakpointsChromaticValues } from "@theme";
 
 import { PartyAccount } from "@components/PartyAccountItem";
 import { PartyAccountItemButton } from "@components/PartyAccountItemButton";
+import { Tag } from "@components/Tag";
 
 const cdnPath = "https://assets.cdn.io.italia.it/logos/organizations/";
 
@@ -112,17 +112,14 @@ const randomValueFromArray = (array: Array<PartyAccount>) => {
 export default {
   title: "Components/PartyAccountItemButton",
   component: PartyAccountItemButton,
-  decorators: [
-    (Story) => (
-      <div
-        style={{
-          padding: "1em",
-        }}
-      >
-        <Story />
-      </div>
-    ),
-  ],
+  parameters: {
+    layout: "padded",
+    chromatic: {
+      viewports: breakpointsChromaticValues.filter(
+        (resolution) => resolution <= 900
+      ),
+    },
+  },
 } as ComponentMeta<typeof PartyAccountItemButton>;
 
 const Template: ComponentStory<typeof PartyAccountItemButton> = (args) => {

--- a/src/components/Showcase/Showcase.stories.tsx
+++ b/src/components/Showcase/Showcase.stories.tsx
@@ -1,5 +1,10 @@
-import { Showcase } from "@components/Showcase";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { breakpointsChromaticValues } from "@theme";
+
+import { Showcase } from "@components/Showcase";
+
+/* Icons */
 import { CieIcon } from "@icons/CieIcon";
 import { MediumIcon } from "@icons/MediumIcon";
 import { SpidIcon } from "@icons/SpidIcon";
@@ -30,15 +35,13 @@ const items = [
 export default {
   title: "Components/Showcase",
   component: Showcase,
-  decorators: [
-    (Story) => (
-      <div style={{ padding: 0, backgroundColor: "#F5F5F5" }}>
-        <Story />
-      </div>
-    ),
-  ],
   args: {
     title: "Title",
+  },
+  parameters: {
+    chromatic: {
+      viewports: breakpointsChromaticValues,
+    },
   },
 } as ComponentMeta<typeof Showcase>;
 

--- a/src/components/TimelineNotification/Timeline.stories.tsx
+++ b/src/components/TimelineNotification/Timeline.stories.tsx
@@ -3,6 +3,9 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Timeline, TimelineConnector } from "@mui/lab";
 import { Chip, Box, Typography } from "@mui/material";
 
+import { breakpointsChromaticValues } from "@theme";
+
+/* Icons */
 import AttachFileRoundedIcon from "@mui/icons-material/AttachFileRounded";
 
 import { ButtonNaked } from "@components/ButtonNaked";
@@ -18,7 +21,12 @@ import {
 export default {
   title: "Components/TimelineNotification",
   component: Timeline,
-  parameters: { controls: { sort: "size" } },
+  parameters: {
+    controls: { sort: "size" },
+    chromatic: {
+      viewports: breakpointsChromaticValues,
+    },
+  },
   backgrounds: [{ name: "dark background", value: "#000", default: true }],
 } as ComponentMeta<typeof Timeline>;
 
@@ -90,7 +98,7 @@ function getTime(dateString: string): string {
 export const Default: ComponentStory<typeof Timeline> = () => (
   <Box
     sx={{
-      width: 450,
+      maxWidth: 450,
       backgroundColor: "background.paper",
       borderRadius: 2,
     }}

--- a/src/components/Walkthrough/Walkthrough.stories.tsx
+++ b/src/components/Walkthrough/Walkthrough.stories.tsx
@@ -1,5 +1,10 @@
-import { Walkthrough } from "@components/Walkthrough";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { Walkthrough } from "@components/Walkthrough";
+
+import { breakpointsChromaticValues } from "@theme";
+
+/* Icons */
 import { CieIcon } from "@icons/CieIcon";
 import { MediumIcon } from "@icons/MediumIcon";
 import { SpidIcon } from "@icons/SpidIcon";
@@ -32,15 +37,13 @@ const items = [
 export default {
   title: "Components/Walkthrough",
   component: Walkthrough,
-  decorators: [
-    (Story) => (
-      <div style={{ padding: 0, backgroundColor: "#F5F5F5" }}>
-        <Story />
-      </div>
-    ),
-  ],
   args: {
     title: "Title",
+  },
+  parameters: {
+    chromatic: {
+      viewports: breakpointsChromaticValues,
+    },
   },
 } as ComponentMeta<typeof Walkthrough>;
 

--- a/src/stories/Alert.stories.tsx
+++ b/src/stories/Alert.stories.tsx
@@ -7,6 +7,8 @@ import { breakpointsChromaticValues } from "@theme";
 /* Icons */
 import CopyAllRoundedIcon from "@mui/icons-material/CopyAllRounded";
 
+const componentMaxWidth = 900;
+
 export default {
   title: "MUI Components/Feedback/Alert",
   component: Alert,
@@ -34,7 +36,9 @@ export default {
   },
   parameters: {
     chromatic: {
-      viewports: breakpointsChromaticValues,
+      viewports: breakpointsChromaticValues.filter(
+        (resolution) => resolution <= componentMaxWidth
+      ),
     },
   },
 } as ComponentMeta<typeof Alert>;

--- a/src/stories/Alert.stories.tsx
+++ b/src/stories/Alert.stories.tsx
@@ -2,6 +2,8 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { Alert, AlertTitle, Button } from "@mui/material";
 
+import { breakpointsChromaticValues } from "@theme";
+
 /* Icons */
 import CopyAllRoundedIcon from "@mui/icons-material/CopyAllRounded";
 
@@ -28,6 +30,11 @@ export default {
         type: { summary: "string" },
         defaultValue: { summary: "standard" },
       },
+    },
+  },
+  parameters: {
+    chromatic: {
+      viewports: breakpointsChromaticValues,
     },
   },
 } as ComponentMeta<typeof Alert>;

--- a/src/stories/Badge.stories.tsx
+++ b/src/stories/Badge.stories.tsx
@@ -15,6 +15,9 @@ export default {
     variant: "standard",
     color: "primary",
   },
+  parameters: {
+    layout: "centered",
+  },
   argTypes: {
     color: {
       options: ["default", "primary", "warning", "info", "error", "success"],

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -34,6 +34,9 @@ export default {
       },
     },
   },
+  parameters: {
+    layout: "padded",
+  },
 } as ComponentMeta<typeof FormControl>;
 
 export const Default: ComponentStory<typeof FormControl> = (args) => {

--- a/src/stories/TextField.stories.tsx
+++ b/src/stories/TextField.stories.tsx
@@ -52,6 +52,9 @@ export default {
       },
     },
   },
+  parameters: {
+    layout: "padded",
+  },
 } as ComponentMeta<typeof TextField>;
 
 const Template: ComponentStory<typeof TextField> = (args) => (

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -170,6 +170,12 @@ declare module "@mui/material/Chip" {
   }
 }
 
+/*
+Used to generate different snapshots per component
+More info:  https://www.chromatic.com/docs/viewports
+*/
+export const breakpointsChromaticValues = [375, 640, 900, 1200];
+
 const foundation: Theme = createTheme({
   breakpoints: {
     values: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -174,7 +174,7 @@ declare module "@mui/material/Chip" {
 Used to generate different snapshots per component
 More info:  https://www.chromatic.com/docs/viewports
 */
-export const breakpointsChromaticValues = [375, 640, 900, 1200];
+export const breakpointsChromaticValues = [375, 640, 900, 1200, 1600];
 
 const foundation: Theme = createTheme({
   breakpoints: {


### PR DESCRIPTION
## Short description
This PR adds Chromatic parameters to generate different snapshots per component, based on the resolution values set in the array `breakpointsChromaticValues`. For more information: https://www.chromatic.com/docs/viewports

⚠️ Viewport checks are not enabled by default

## List of changes proposed in this pull request
- Add the array `breakpointsChromaticValues`, imported by some complex components
- Add a local const `componentMaxWidth` to set a resolution upper limit of the viewport checks (eg: components that should be tested with a `500px` max-width)