### PR TITLE
[MUI-172] Add the new `monospaced` typographic variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/pagopa/mui-italia/issues"
   },
   "dependencies": {
+    "@fontsource/dm-mono": "^4.5.10",
     "@fontsource/titillium-web": "^4.5.9",
     "clsx": "^1.2.1",
     "fp-ts": "^2.12.3",

--- a/src/stories/Typography.stories.tsx
+++ b/src/stories/Typography.stories.tsx
@@ -21,6 +21,7 @@ export default {
         "sidenav",
         "caption",
         "caption-semibold",
+        "monospaced",
       ],
       control: { type: "select" },
     },
@@ -115,4 +116,10 @@ export const CaptionSemiBold = Template.bind({});
 CaptionSemiBold.args = {
   variant: "caption-semibold",
   children: "Caption Semibold",
+};
+
+export const Monospaced = Template.bind({});
+Monospaced.args = {
+  variant: "monospaced",
+  children: "IT 99 C 12345 67890 123456789012",
 };

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -5,10 +5,13 @@ import { indigo } from "@mui/material/colors";
 import { italia } from "@tokens";
 
 /* Typefaces */
+/* -- Titilium */
 import "@fontsource/titillium-web/300.css";
 import "@fontsource/titillium-web/400.css";
 import "@fontsource/titillium-web/600.css";
 import "@fontsource/titillium-web/700.css";
+/* -- DM Mono */
+import "@fontsource/dm-mono/400.css";
 
 export function pxToRem(value: number): string {
   return `${value / 16}rem`;
@@ -16,6 +19,7 @@ export function pxToRem(value: number): string {
 
 /* Basic Configuration */
 const mainTypeface = ['"Titillium Web"', "sans-serif"].join(", ");
+const monospacedTypeface = ['"DM Mono"', "monospace"].join(", ");
 const colorTextPrimary = "#17324D";
 const colorPrimaryContainedHover = "#0055AA"; // Not exposed by the theme object
 const responsiveBreakpoint = "sm";
@@ -47,12 +51,14 @@ declare module "@mui/material/styles" {
   interface TypographyVariants {
     headline: React.CSSProperties;
     sidenav: React.CSSProperties;
+    monospaced: React.CSSProperties;
     "caption-semibold": React.CSSProperties;
   }
 
   interface TypographyVariantsOptions {
     headline?: React.CSSProperties;
     sidenav?: React.CSSProperties;
+    monospaced?: React.CSSProperties;
     "caption-semibold"?: React.CSSProperties;
   }
 }
@@ -60,6 +66,7 @@ declare module "@mui/material/Typography" {
   interface TypographyPropsVariantOverrides {
     headline: true;
     sidenav: true;
+    monospaced: true;
     "caption-semibold": true;
   }
 }
@@ -403,6 +410,14 @@ export const theme: Theme = createTheme(foundation, {
       lineHeight: 1.4 /* ~20px */,
       color: colorTextPrimary,
       fontWeight: foundation.typography.fontWeightMedium,
+    },
+    monospaced: {
+      fontFamily: monospacedTypeface,
+      fontSize: pxToRem(16),
+      lineHeight: 1.4 /* ~22px */,
+      color: colorTextPrimary,
+      letterSpacing: "0.15px",
+      fontWeight: foundation.typography.fontWeightRegular,
     },
     overline: {
       fontSize: pxToRem(14),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,6 +1477,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@fontsource/dm-mono@^4.5.10":
+  version "4.5.10"
+  resolved "https://registry.yarnpkg.com/@fontsource/dm-mono/-/dm-mono-4.5.10.tgz#2d033549b4fe75ab8e26c5e74081f1ba5aa65519"
+  integrity sha512-cVd0L+tz1PrrNyClnpeJvRtVdvtB69L9PJ4sBm3t2ZCcbzKCa3MmW9duljKeRxTfQh3YTZpevnD14uWumRJYzA==
+
 "@fontsource/titillium-web@^4.5.9":
   version "4.5.9"
   resolved "https://registry.yarnpkg.com/@fontsource/titillium-web/-/titillium-web-4.5.9.tgz#9de41e7b27fd6913055c2e9f616e5a2c5180f121"


### PR DESCRIPTION
## Short description
This PR adds the new `monospaced` typographic variant through the `<Typography>` component. This typographic variant is especially helpful when you have a long sequence of mixed letters and numbers (e.g: IBAN code): the user can clearly see the differences between the glyph `O` (uppercase letter o) and `0` (zero number).

### Preview
<img width="377" alt="Screenshot 2022-11-08 at 11 11 03" src="https://user-images.githubusercontent.com/1255491/200537269-9bc25013-2d8a-4206-9fd6-cbb7e478606c.png">


## List of changes proposed in this pull request
- Add the new `monospaced` typographic variant through the theme configuration file (`theme.ts`)
- Add relative story to Storybook

## Product
ID Pay

## How to test
Run `$ yarn storybook` to launch a local instance of Storybook