### PR TITLE
SELC-1721 Add the property `tabIndex` to PartyAccountItemButton

### DIFF
--- a/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
+++ b/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
@@ -68,6 +68,7 @@ export const PartyAccountItemButton = ({
         }),
       }}
       role="button"
+      tabIndex={0}
       onClick={action}
     >
       <Box sx={{ display: "flex", flexDirection: "row" }}>


### PR DESCRIPTION
## Short description
In the PartyAccountItemButton component, the property tabIndex is setted to zero in order to make it accessible to the focus also from keyboard commands.

### Preview

## List of changes proposed in this pull request

## Product
Area Riservata

## How to test
After updating the dependencies on the selfcare repositories, the drawer menu and the party selection of dashboard and the party selection of onboarding flows will be accessible also by pressing the TAB key on the keyboard.