### PR TITLE
SELC-1721_partySwitchAccessibility Add also in the PartySwitch component the property tabIndex setted to zero in order to make it accessible to the focus also from keyboard commands

### DIFF
--- a/src/components/PartySwitch/PartySwitch.tsx
+++ b/src/components/PartySwitch/PartySwitch.tsx
@@ -133,6 +133,7 @@ export const PartySwitch = ({
         anchor="right"
         open={open}
         onClose={() => toggleDrawer(false)}
+        tabIndex={0}
       >
         <Box sx={{ textAlign: "center", margin: "10px 0" }}>
           <Typography variant="overline">Accedi per un altro ente</Typography>


### PR DESCRIPTION
## Short description
In the PartySwitch component, the property tabIndex is now setted to zero in order to make it accessible to the focus also from keyboard commands.

### Preview

## List of changes proposed in this pull request

## Product
Area Riservata

## How to test
Now the drawer menu it allows you to access each result by also pressing the tab key on the keyboard.