### PR TITLE
SELC-1721 Make the closeIcon of customDrawerMenu focusable and clickable also with keyboard commands

### DIFF
--- a/src/components/PartySwitch/PartySwitch.tsx
+++ b/src/components/PartySwitch/PartySwitch.tsx
@@ -133,6 +133,7 @@ export const PartySwitch = ({
         anchor="right"
         open={open}
         onClose={() => toggleDrawer(false)}
+        tabIndex={0}
       >
         <Box sx={{ textAlign: "center", margin: "10px 0" }}>
           <Typography variant="overline">Accedi per un altro ente</Typography>

--- a/src/components/PartySwitch/PartySwitch.tsx
+++ b/src/components/PartySwitch/PartySwitch.tsx
@@ -15,6 +15,7 @@ import {
   InputAdornment,
   TextField,
   Typography,
+  IconButton,
 } from "@mui/material";
 import { alpha, styled } from "@mui/material/styles";
 import { ButtonUnstyledProps, useButton } from "@mui/base/ButtonUnstyled";
@@ -152,7 +153,9 @@ export const PartySwitch = ({
                 onClick={() => setFilter("")}
                 sx={{ cursor: "pointer" }}
               >
-                <CloseIcon />
+                <IconButton aria-label="elimina">
+                  <CloseIcon />
+                </IconButton>
               </InputAdornment>
             ),
           }}


### PR DESCRIPTION
## Short description
For obtain this result, the closeIcon of mui icons-material has been wrapped into IconButton component of mui material. It has also been added an aria-label for give more accurate description of the purpose of the button.

### Preview

## List of changes proposed in this pull request

## Product
Area Riservata

## How to test
Now, opening the customDrawerMenu and type at least one character, is possible focus the closeIcon by pressing TAB key and pressing ENTER or SPACE, you are able to remove the string typed in the search.