### PR TITLE
The component customDrawer set correctly the selectedParty also by the keyboard

### DIFF
--- a/src/components/PartySwitch/PartySwitch.tsx
+++ b/src/components/PartySwitch/PartySwitch.tsx
@@ -133,6 +133,17 @@ export const PartySwitch = ({
       <CustomDrawer
         anchor="right"
         open={open}
+        onKeyDownCapture={(e) => {
+          if (e.key === "Enter") {
+            const partySelected = (e as any).target;
+            const selectedParty = filteredParties.find((p: PartySwitchItem) =>
+              partySelected.textContent.includes(p.name)
+            );
+            if (selectedParty) {
+              handlePartySelection(selectedParty);
+            }
+          }
+        }}
         onClose={() => toggleDrawer(false)}
         tabIndex={0}
       >


### PR DESCRIPTION
## Short description
The customDrawer now intercepts the keyboard press and correctly sets the selectedProduct with the user selection

### Preview

## List of changes proposed in this pull request

## Product

## How to test
Browsing among the occurrences available in the switch, as soon as you click ENTER on the keyboard, the customDrawer will be closed and the selectedParty will be set correctly