### PR TITLE
PASELC-54 HeaderProduct: adds Chip component and makes the bottom border configurable

### DIFF
--- a/src/components/HeaderProduct/HeaderProduct.stories.tsx
+++ b/src/components/HeaderProduct/HeaderProduct.stories.tsx
@@ -215,7 +215,7 @@ export const WithProductSelectionWithPartySelectionWithChip: ComponentStory<
     borderBottom={3}
     borderColor={theme.palette.warning.main}
     chipColor="warning"
-    chipLabel="Ambiente di Collaudo"
+    chipLabel="Collaudo"
     productsList={productsList}
     partyList={partyList}
     onSelectedParty={(e) => console.log("Selected Item:", e.name)}

--- a/src/components/HeaderProduct/HeaderProduct.stories.tsx
+++ b/src/components/HeaderProduct/HeaderProduct.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { breakpointsChromaticValues } from "@theme";
+import { breakpointsChromaticValues, theme } from "@theme";
 
 import {
   HeaderProduct,
@@ -147,10 +147,25 @@ export const DefaultWithoutParties: ComponentStory<
   typeof HeaderProduct
 > = () => <HeaderProduct productsList={[productsList[0]]} />;
 
+export const DefaultWithoutPartiesWithChip: ComponentStory<
+  typeof HeaderProduct
+> = () => <HeaderProduct chipLabel="Beta" productsList={[productsList[0]]} />;
+
 export const WithProductSelection: ComponentStory<
   typeof HeaderProduct
 > = () => (
   <HeaderProduct
+    productId="1"
+    productsList={productsList}
+    onSelectedProduct={(p) => console.log("Selected Item:", p.title)}
+    partyList={[partyList[0]]}
+  />
+);
+export const WithProductSelectionWithChip: ComponentStory<
+  typeof HeaderProduct
+> = () => (
+  <HeaderProduct
+    chipLabel="Beta"
     productId="1"
     productsList={productsList}
     onSelectedProduct={(p) => console.log("Selected Item:", p.title)}
@@ -164,9 +179,44 @@ export const WithoutProductSelection: ComponentStory<
   <HeaderProduct productsList={[productsList[0]]} partyList={[partyList[0]]} />
 );
 
+export const WithoutProductSelectionWithChip: ComponentStory<
+  typeof HeaderProduct
+> = () => (
+  <HeaderProduct
+    chipLabel="Beta"
+    productsList={[productsList[0]]}
+    partyList={[partyList[0]]}
+  />
+);
+
 export const WithPartySelection: ComponentStory<typeof HeaderProduct> = () => (
   <HeaderProduct
     productsList={[productsList[0]]}
+    partyList={partyList}
+    onSelectedParty={(e) => console.log("Selected Item:", e.name)}
+  />
+);
+
+export const WithPartySelectionWithChip: ComponentStory<
+  typeof HeaderProduct
+> = () => (
+  <HeaderProduct
+    chipLabel="Beta"
+    productsList={[productsList[0]]}
+    partyList={partyList}
+    onSelectedParty={(e) => console.log("Selected Item:", e.name)}
+  />
+);
+
+export const WithProductSelectionWithPartySelectionWithChip: ComponentStory<
+  typeof HeaderProduct
+> = () => (
+  <HeaderProduct
+    borderBottom={3}
+    borderColor={theme.palette.warning.main}
+    chipColor="warning"
+    chipLabel="Ambiente di Collaudo"
+    productsList={productsList}
     partyList={partyList}
     onSelectedParty={(e) => console.log("Selected Item:", e.name)}
   />

--- a/src/components/HeaderProduct/HeaderProduct.tsx
+++ b/src/components/HeaderProduct/HeaderProduct.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Box, Container, Stack, Typography } from "@mui/material";
+import { Box, Chip, Container, Stack, Typography } from "@mui/material";
 
 import { ProductSwitch, ProductSwitchItem } from "@components/ProductSwitch";
 import { PartySwitchItem, PartySwitch } from "@components/PartySwitch";
@@ -9,27 +9,45 @@ export type ProductEntity = ProductSwitchItem;
 export type PartyEntity = PartySwitchItem;
 
 export type HeaderProductProps = {
-  productId?: string;
-  productsList: Array<ProductEntity>;
-  partyId?: string;
-  partyList?: Array<PartyEntity>;
-  onSelectedProduct?: (product: ProductSwitchItem) => void;
-  onSelectedParty?: (party: PartySwitchItem) => void;
+  borderBottom?: number;
+  borderColor?: string;
+  chipColor?:
+    | "default"
+    | "indigo"
+    | "primary"
+    | "secondary"
+    | "error"
+    | "info"
+    | "success"
+    | "warning";
+  chipLabel?: string;
+  chipSize?: "small" | "medium";
   /* The number of characters beyond which the multiLine is applied in component PartyAccountItemButton */
   maxCharactersNumberMultiLineButton?: number;
   /* The number of characters beyond which the multiLine is applied in component PartyAccountItem */
   maxCharactersNumberMultiLineItem?: number;
+  onSelectedParty?: (party: PartySwitchItem) => void;
+  onSelectedProduct?: (product: ProductSwitchItem) => void;
+  partyId?: string;
+  partyList?: Array<PartyEntity>;
+  productId?: string;
+  productsList: Array<ProductEntity>;
 };
 
 export const HeaderProduct = ({
-  productId,
-  productsList,
-  partyId,
-  partyList,
-  onSelectedProduct,
-  onSelectedParty,
+  borderBottom,
+  borderColor,
+  chipColor = "primary",
+  chipLabel,
+  chipSize = "small",
   maxCharactersNumberMultiLineButton,
   maxCharactersNumberMultiLineItem,
+  onSelectedParty,
+  onSelectedProduct,
+  partyId,
+  partyList,
+  productId,
+  productsList,
 }: HeaderProductProps) => {
   const selectedProduct = useMemo(
     () =>
@@ -45,45 +63,63 @@ export const HeaderProduct = ({
     return partyId ? partyList.find((e) => e.id === partyId) : partyList[0];
   }, [partyList, partyId]) as PartySwitchItem;
 
+  const ChipComponent = (
+    <Chip
+      sx={{
+        py: 0,
+        "& .MuiChip-labelSmall": {
+          py: "2px",
+        },
+      }}
+      color={chipColor}
+      label={chipLabel}
+      size={chipSize}
+    ></Chip>
+  );
+
   return (
     <Box
       component="div"
       display="flex"
       alignItems="center"
       sx={{
-        borderBottom: 1,
-        borderColor: "divider",
         backgroundColor: "background.paper",
-        minHeight: { xs: "auto", md: "80px" },
+        borderBottom: borderBottom ?? 1,
+        borderColor: borderColor ?? "divider",
         boxSizing: "border-box",
+        minHeight: { xs: "auto", md: "80px" },
       }}
     >
       <Container maxWidth={false}>
         <Stack
-          spacing={2}
+          alignItems="center"
           direction="row"
           justifyContent="space-between"
-          alignItems="center"
+          spacing={2}
           sx={{ py: 2 }}
         >
           {/* Left side of the component */}
           {productsList.length > 1 && (
-            <>
+            <Stack spacing={2} direction="row" alignItems="center">
               {/* Switcher Product */}
               <ProductSwitch
                 currentProductId={selectedProduct.id}
                 products={productsList}
                 onExit={onSelectedProduct}
               ></ProductSwitch>
-            </>
+              {chipLabel && chipLabel !== "" && ChipComponent}
+            </Stack>
           )}
 
           {selectedProduct && productsList.length === 1 && (
-            <Typography
-              sx={{ fontSize: { xs: 20, sm: 28 }, fontWeight: "bold" }}
-            >
-              {selectedProduct?.title}
-            </Typography>
+            <Stack spacing={2} direction="row" alignItems="center">
+              <Typography
+                sx={{ fontSize: { xs: 20, sm: 28 }, fontWeight: "bold" }}
+              >
+                {selectedProduct?.title}
+              </Typography>
+              {chipLabel && chipLabel !== "" && ChipComponent}
+            </Stack>
           )}
 
           {/* insert maxWidth to limit component width when the const multiLine is used in PartySwitch and PartyAccountItem */}

--- a/src/components/HeaderProduct/HeaderProduct.tsx
+++ b/src/components/HeaderProduct/HeaderProduct.tsx
@@ -7,19 +7,20 @@ import { PartyAccountItem } from "@components/PartyAccountItem";
 
 export type ProductEntity = ProductSwitchItem;
 export type PartyEntity = PartySwitchItem;
+export type ChipColors =
+  | "default"
+  | "indigo"
+  | "primary"
+  | "secondary"
+  | "error"
+  | "info"
+  | "success"
+  | "warning";
 
 export type HeaderProductProps = {
   borderBottom?: number;
   borderColor?: string;
-  chipColor?:
-    | "default"
-    | "indigo"
-    | "primary"
-    | "secondary"
-    | "error"
-    | "info"
-    | "success"
-    | "warning";
+  chipColor?: ChipColors;
   chipLabel?: string;
   chipSize?: "small" | "medium";
   /* The number of characters beyond which the multiLine is applied in component PartyAccountItemButton */


### PR DESCRIPTION
## Short description
Edit the HeaderProduct component to accept a textual chip and make the bottom border configurable in size and color

## List of changes proposed in this pull request
- Adds the ability to render a Chip between the Product switch and the Party switch inside the HeaderProduct. The chip is configurable in textual content, color and size.
- Adds the ability to change the color and size of the default bottom border of the HeaderProduct.

## Product
Selfcare Back-office pagoPA

## How to test
Some stories have been added in the Components/HeaderProduct section that can be tested with Storybook or Chromatic:
- Default Without Parties With Chip
- With Product Selection With Chip
- Without Product Selection With Chip
- With Party Selection With Chip
- With Product Selection With Party Selection With Chip
 