### PR TITLE
[MUI-189] HeaderAccount documentation button

### DIFF
--- a/src/components/HeaderAccount/HeaderAccount.stories.tsx
+++ b/src/components/HeaderAccount/HeaderAccount.stories.tsx
@@ -131,3 +131,15 @@ export const WithoutAssistance: ComponentStory<typeof HeaderAccount> = () => (
     }}
   />
 );
+
+export const WithDocumentation: ComponentStory<typeof HeaderAccount> = () => (
+  <HeaderAccount
+    rootLink={pagoPALink}
+    onDocumentationClick={() => {
+      console.log("Clicked/Tapped on Assistance");
+    }}
+    onAssistanceClick={() => {
+      console.log("Clicked/Tapped on Assistance");
+    }}
+  />
+);

--- a/src/components/HeaderAccount/HeaderAccount.tsx
+++ b/src/components/HeaderAccount/HeaderAccount.tsx
@@ -5,6 +5,7 @@ import { AccountDropdown } from "@components/AccountDropdown";
 
 /* Icons */
 import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
+import DescriptionIcon from "@mui/icons-material/Description";
 
 export type JwtUser = {
   id: string;
@@ -37,6 +38,7 @@ type HeaderAccountProps = {
   enableDropdown?: boolean;
   enableLogin?: boolean;
   enableAssistanceButton?: boolean;
+  onDocumentationClick?: () => void;
 };
 
 export const HeaderAccount = ({
@@ -44,6 +46,7 @@ export const HeaderAccount = ({
   loggedUser,
   userActions,
   onAssistanceClick,
+  onDocumentationClick,
   onLogout,
   onLogin,
   enableDropdown = false,
@@ -87,6 +90,31 @@ export const HeaderAccount = ({
           alignItems="center"
           spacing={{ xs: 1, sm: 3, md: 4 }}
         >
+          {/* START Documentation MOBILE/DESKTOP */}
+          {onDocumentationClick && (
+            <>
+              <ButtonNaked
+                size="small"
+                component="button"
+                onClick={onDocumentationClick}
+                startIcon={<DescriptionIcon />}
+                sx={{ display: ["none", "flex"] }}
+                weight="default"
+              >
+                Documentazione
+              </ButtonNaked>
+              <IconButton
+                size="small"
+                aria-label="Documentazione"
+                sx={{ display: ["flex", "none"] }}
+                onClick={onDocumentationClick}
+              >
+                <DescriptionIcon fontSize="inherit" />
+              </IconButton>
+            </>
+          )}
+          {/* END Documentation MOBILE/DESKTOP */}
+
           {/* START Assistance MOBILE/DESKTOP */}
           {enableAssistanceButton && (
             <>


### PR DESCRIPTION
## Short description
Added prop `onDocumentationClick` to `HeaderAccount` component. If the prop is passed, the documentation button will be rendered. The button will be rendered on the left of the assistance button.

### Preview
Desktop view:
![Desktop view](https://user-images.githubusercontent.com/62668966/227904218-db4e6bc5-07bd-4a9f-9bf3-d0f14fcc83a3.png)
Mobile view:
![Mobile view](https://user-images.githubusercontent.com/62668966/227904448-9945887d-a1bb-42ba-8b8a-d35ecb85ba4f.png)

## Product
PDND Interoperabilità

## How to test
Added `WithDocumentation` to `HeaderAccount` stories.