### PR TITLE
Fix: HeaderProduct calls outdated onSelectedProduct callback reference  

### DIFF
--- a/src/components/ProductSwitch/ProductSwitch.tsx
+++ b/src/components/ProductSwitch/ProductSwitch.tsx
@@ -1,11 +1,4 @@
-import {
-  ForwardedRef,
-  forwardRef,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { ForwardedRef, forwardRef, useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
 import { Menu, MenuItem, Typography } from "@mui/material";
 import { styled } from "@mui/system";
@@ -54,20 +47,17 @@ export const ProductSwitch = ({
     setAnchorEl(event.currentTarget);
   };
 
-  const handleClose = useCallback(
-    (product?: ProductSwitchItem) => {
-      if (product) {
-        if (product.linkType === "internal") {
-          setSelectedId(product.id);
-        }
-        if (onExit) {
-          onExit(product);
-        }
+  const handleClose = (product?: ProductSwitchItem) => {
+    if (product) {
+      if (product.linkType === "internal") {
+        setSelectedId(product.id);
       }
-      setAnchorEl(null);
-    },
-    [selectedId]
-  );
+      if (onExit) {
+        onExit(product);
+      }
+    }
+    setAnchorEl(null);
+  };
 
   return (
     <>


### PR DESCRIPTION
## Short description
This PR contains a fix to a problem where the `HeaderProduct` component was not calling the updated reference of the passed `onSelectedProduct` callback function.

The reason of the bug is due to a missing dependency in the handleClose's useCallback dependency array (`onExit`).

The fix removed completely `useCallback` since it is not really needed in this context.

## Product
PDND Interoperabilità