### PR TITLE
[MUI-185] - EnvironmentBanner component

### DIFF
--- a/src/components/EnvironmentBanner/EnvironmentBanner.stories.tsx
+++ b/src/components/EnvironmentBanner/EnvironmentBanner.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { breakpointsChromaticValues } from "@theme";
+import { EnvironmentBanner } from "./EnvironmentBanner";
+
+const componentMaxWidth = 900;
+
+export default {
+  title: "Components/EnvironmentBanner",
+  component: EnvironmentBanner,
+  parameters: {
+    chromatic: {
+      viewports: breakpointsChromaticValues.filter(
+        (resolution) => resolution <= componentMaxWidth
+      ),
+    },
+  },
+} as ComponentMeta<typeof EnvironmentBanner>;
+
+export const Default: ComponentStory<typeof EnvironmentBanner> = (args) => (
+  <EnvironmentBanner {...args} />
+);

--- a/src/components/EnvironmentBanner/EnvironmentBanner.tsx
+++ b/src/components/EnvironmentBanner/EnvironmentBanner.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Alert, Typography } from "@mui/material";
+
+interface EnvironmentBannerProps {
+  env: "test" | "prod";
+  message: string;
+  icon?: React.ReactNode;
+}
+
+export function EnvironmentBanner({
+  env,
+  message,
+  icon,
+}: EnvironmentBannerProps) {
+  const bgcolor = env === "test" ? "warning.extraLight" : "background.default";
+  return (
+    <Alert
+      sx={{
+        borderLeft: "none",
+        borderRadius: 0,
+        alignItems: "center",
+        justifyContent: "center",
+        bgcolor,
+        "&.MuiPaper-root": {
+          px: { xs: 1, sm: 3 },
+          py: 1,
+        },
+      }}
+      icon={icon ?? false}
+    >
+      <Typography
+        variant="body2"
+        sx={{ maxWidth: 480, textAlign: "center", wordBreak: "break-word" }}
+      >
+        {message}
+      </Typography>
+    </Alert>
+  );
+}

--- a/src/components/EnvironmentBanner/index.ts
+++ b/src/components/EnvironmentBanner/index.ts
@@ -1,0 +1,1 @@
+export * from "./EnvironmentBanner";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -25,3 +25,4 @@ export * from "./ProductAvatar";
 export * from "./TOSAgreement";
 export * from "./SingleFileInput";
 export * from "./CopyToClipboardButton";
+export * from "./EnvironmentBanner";


### PR DESCRIPTION
## Short description
Added `EnvironmentBanner` component.

### Props
- **env**: required, "prod" or "test". Changes the banner background based on the actual environment;
- **message**: required. Text to display inside the banner;
- **icon**: optional.

## Preview
```jsx
<EnvironmentBanner 
  env="prod" 
  message="Ambiente di collaudo: attenzione i dati non devono essere reali" 
  icon={ <WarningAmberIcon fontSize="small" /> } 
/>
```
<img width="959" alt="Schermata 2023-05-09 alle 12 16 55" src="https://github.com/pagopa/mui-italia/assets/62668966/3cb4b973-057f-4c6e-9108-940d5186e6cc">

## How to test
`EnvironmentBanner` story.
