### PR TITLE
fix: change sidemenu items color from primary main to primary dark

### DIFF
--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -953,13 +953,13 @@ export const theme: Theme = createTheme(foundation, {
           paddingBottom: foundation.spacing(2),
           /* Selected State */
           "&.Mui-selected": {
-            borderColor: foundation.palette.primary.main,
+            borderColor: foundation.palette.primary.dark,
           },
           "&.Mui-selected .MuiListItemText-root": {
-            color: foundation.palette.primary.main,
+            color: foundation.palette.primary.dark,
           },
           "&.Mui-selected .MuiListItemIcon-root": {
-            color: foundation.palette.primary.main,
+            color: foundation.palette.primary.dark,
           },
         },
       },


### PR DESCRIPTION
## Short description
To fix the accessibility issue highlighted from the lighthouse tool, the color of the selected SideMenuItem has been changed to primary.dark from primary.main.

### Preview
New color for selected item
<img width="391" alt="Screenshot 2023-05-17 at 16 00 56" src="https://github.com/pagopa/mui-italia/assets/100523847/c10ba17d-0d23-40d3-b4bd-ed167bbc7bf1">


## List of changes proposed in this pull request
-  Change sidemenu items color from primary main to primary dark

## How to test
Check that the icon, text and border color is  #0062C3 and not #0073E6.