### PR TITLE
fix: change MuiListItemButton border to be present only on selection

### DIFF
--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -946,14 +946,13 @@ export const theme: Theme = createTheme(foundation, {
       },
       styleOverrides: {
         root: {
-          borderRight: "2px solid transparent",
           transitionProperty: "background-color, border-color",
           transitionDuration: foundation.transitions.duration.standard,
           paddingTop: foundation.spacing(2),
           paddingBottom: foundation.spacing(2),
           /* Selected State */
           "&.Mui-selected": {
-            borderColor: foundation.palette.primary.main,
+            borderRight: `2px solid ${foundation.palette.primary.main}`,
           },
           "&.Mui-selected .MuiListItemText-root": {
             color: foundation.palette.primary.main,


### PR DESCRIPTION
## Short description
Change MuiListItemButton to show border only on selection, accordingly to [PN-5524](https://pagopa.atlassian.net/browse/PN-5524) due to accessibility reasons in high contrast mode.

## List of changes proposed in this pull request
- Removes transparent border from SideMenuItem root style
- Adds transparent 

## Product
Piattaforma Notifiche

## How to test
The behavior should be tested in windows high contrast mode, however the presence or absence of the border can be checked with the inspection tools

[PN-5524]: https://pagopa.atlassian.net/browse/PN-5524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ