### PR TITLE
fix(PN-5714): adds overrides for MuiBreadcrumbs style in theme.ts

### DIFF
--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -597,6 +597,18 @@ export const theme: Theme = createTheme(foundation, {
           fontSize: pxToRem(16),
           color: foundation.palette.text.primary,
         },
+        li: {
+          "a:hover": {
+            textDecoration: "none",
+          },
+          p: {
+            fontSize: `${pxToRem(16)} !important`,
+          },
+          svg: {
+            fontSize: pxToRem(20),
+            marginRight: foundation.spacing(1.5),
+          },
+        },
         separator: {
           color: foundation.palette.text.secondary,
         },


### PR DESCRIPTION
## Short description
Changes MuiBreadcrumbs style accordingly to [PN-5714](https://pagopa.atlassian.net/browse/PN-5714)

### Preview
Developed:
<img width="254" alt="Screenshot 2023-05-19 at 17 19 58" src="https://github.com/pagopa/mui-italia/assets/100523847/aedee4d8-728f-4d97-87cc-cb6ceb3f272f">

Design:
<img width="267" alt="Screenshot 2023-05-19 at 17 20 40" src="https://github.com/pagopa/mui-italia/assets/100523847/c42e6496-d2b9-4b86-b705-77cd9a0d3d9a">


## List of changes proposed in this pull request
- Changes p font-size in breadcrumbs from 18px to 16px
- Removes underline while hovering breadcrumbs links
- Changes breadcrumbs icon size from default to 20px and increases right margin from 8 to 12

## Product
Piattaforma Notifiche

## How to test
Check that the new style matches the [design](https://www.figma.com/file/pNBaYInnJjgyg1BZ1VeuJq/MUI-Italia---Design-System?type=design&node-id=6572-50395&t=bGlP4sx6t8YUYi31-0)

[PN-5714]: https://pagopa.atlassian.net/browse/PN-5714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ