### PR TITLE
build: [SFEQS-1882] Add "use client" directive in components

### DIFF
--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from "react";
 import {
   Menu,

--- a/src/components/ButtonNaked/ButtonNaked.tsx
+++ b/src/components/ButtonNaked/ButtonNaked.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Button, ButtonProps } from "@mui/material";
 

--- a/src/components/CopyToClipboardButton/CopyToClipboardButton.tsx
+++ b/src/components/CopyToClipboardButton/CopyToClipboardButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useRef, useEffect } from "react";
 import { IconButton, Tooltip } from "@mui/material";
 import type { IconButtonProps } from "@mui/material";

--- a/src/components/EnvironmentBanner/EnvironmentBanner.tsx
+++ b/src/components/EnvironmentBanner/EnvironmentBanner.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Alert, Typography } from "@mui/material";
 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Box } from "@mui/material";
 import { FooterLegal } from "@components/FooterLegal";
 import { FooterPostLogin } from "@components/FooterPostLogin";

--- a/src/components/FooterCheckout/FooterCheckout.tsx
+++ b/src/components/FooterCheckout/FooterCheckout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Stack, Box, Link } from "@mui/material";
 import { CompanyLinkType, FooterLinksType } from "@components/Footer";
 import { LangSwitch, LangSwitchProps } from "@components/LangSwitch";

--- a/src/components/FooterLegal/FooterLegal.tsx
+++ b/src/components/FooterLegal/FooterLegal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Box, Container, Typography } from "@mui/material";
 
 export interface FooterLegalProps {

--- a/src/components/FooterPostLogin/FooterPostLogin.tsx
+++ b/src/components/FooterPostLogin/FooterPostLogin.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Stack, Box, Container, Link } from "@mui/material";
 import { CompanyLinkType, FooterLinksType } from "@components/Footer";
 import { LangSwitch, LangSwitchProps } from "@components/LangSwitch";

--- a/src/components/FooterPreLogin/FooterPreLogin.tsx
+++ b/src/components/FooterPreLogin/FooterPreLogin.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from "react";
 import { Grid, Stack, Box, Typography, Container, Link } from "@mui/material";
 import { CompanyLinkType, PreLoginFooterLinksType } from "@components/Footer";

--- a/src/components/HeaderAccount/HeaderAccount.tsx
+++ b/src/components/HeaderAccount/HeaderAccount.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Container, Button, Stack, IconButton } from "@mui/material";
 import { ButtonNaked } from "@components/ButtonNaked";

--- a/src/components/HeaderProduct/HeaderProduct.tsx
+++ b/src/components/HeaderProduct/HeaderProduct.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useMemo } from "react";
 import { Box, Chip, Container, Stack, Typography } from "@mui/material";
 

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Box, Button, Stack, Typography, Container } from "@mui/material";
 import { CTA } from "@types";
 

--- a/src/components/HorizontalNav/HorizontalNav.tsx
+++ b/src/components/HorizontalNav/HorizontalNav.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Box,
   Button,

--- a/src/components/Illustration/Illustration.tsx
+++ b/src/components/Illustration/Illustration.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 
 // Components

--- a/src/components/Infoblock/Infoblock.tsx
+++ b/src/components/Infoblock/Infoblock.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Box, Button, Container, Stack, Typography } from "@mui/material";
 import { CTA } from "@types";
 export interface InfoblockProps {

--- a/src/components/LangSwitch/LangSwitch.tsx
+++ b/src/components/LangSwitch/LangSwitch.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from "react";
 import { Menu, MenuItem, Typography, Box } from "@mui/material";
 import { ButtonNaked } from "@components/ButtonNaked";

--- a/src/components/PartyAccountItem/PartyAccountItem.tsx
+++ b/src/components/PartyAccountItem/PartyAccountItem.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Typography, Box, SxProps } from "@mui/material";
 import { useMemo } from "react";
 import { Tooltip } from "@mui/material";

--- a/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
+++ b/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 
 import { Typography, Box, Tooltip } from "@mui/material";

--- a/src/components/PartyAvatar/PartyAvatar.tsx
+++ b/src/components/PartyAvatar/PartyAvatar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Avatar } from "@mui/material";
 
 import AccountBalanceRoundedIcon from "@mui/icons-material/AccountBalanceRounded";

--- a/src/components/PartySwitch/PartySwitch.tsx
+++ b/src/components/PartySwitch/PartySwitch.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   ChangeEvent,
   ForwardedRef,

--- a/src/components/ProductAvatar/ProductAvatar.tsx
+++ b/src/components/ProductAvatar/ProductAvatar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Box } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 

--- a/src/components/ProductSwitch/ProductSwitch.tsx
+++ b/src/components/ProductSwitch/ProductSwitch.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ForwardedRef, forwardRef, useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
 import { Menu, MenuItem, Typography } from "@mui/material";

--- a/src/components/Showcase/Showcase.tsx
+++ b/src/components/Showcase/Showcase.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Box, Container, Stack, Typography } from "@mui/material";
 
 export interface ShowcaseItem {

--- a/src/components/SingleFileInput/SingleFileInput.tsx
+++ b/src/components/SingleFileInput/SingleFileInput.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useRef, ChangeEvent, DragEvent, ReactNode, useState } from "react";
 import {
   Box,

--- a/src/components/TOSAgreement/TOSAgreement.tsx
+++ b/src/components/TOSAgreement/TOSAgreement.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Stack, Typography, Box, Button } from "@mui/material";
 import { SxProps } from "@mui/system";

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/system";
 import { alpha } from "@mui/material/styles";
 

--- a/src/components/TagGroup/TagGroup.tsx
+++ b/src/components/TagGroup/TagGroup.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 
 // Components

--- a/src/components/TimelineNotification/TimelineNotification.tsx
+++ b/src/components/TimelineNotification/TimelineNotification.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Timeline, TimelineProps } from "@mui/lab";
 import { theme } from "@theme";

--- a/src/components/TimelineNotification/TimelineNotificationContent.tsx
+++ b/src/components/TimelineNotification/TimelineNotificationContent.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { TimelineContent, TimelineContentProps } from "@mui/lab";
 import { Stack } from "@mui/material";

--- a/src/components/TimelineNotification/TimelineNotificationDot.tsx
+++ b/src/components/TimelineNotification/TimelineNotificationDot.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { TimelineDot, TimelineDotProps } from "@mui/lab";
 import { theme } from "@theme";

--- a/src/components/TimelineNotification/TimelineNotificationItem.tsx
+++ b/src/components/TimelineNotification/TimelineNotificationItem.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { TimelineItem, TimelineItemProps } from "@mui/lab";
 

--- a/src/components/TimelineNotification/TimelineNotificationOppositeContent.tsx
+++ b/src/components/TimelineNotification/TimelineNotificationOppositeContent.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import {
   TimelineOppositeContent,

--- a/src/components/TimelineNotification/TimelineNotificationSeparator.tsx
+++ b/src/components/TimelineNotification/TimelineNotificationSeparator.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { TimelineSeparator, TimelineSeparatorProps } from "@mui/lab";
 

--- a/src/components/Walkthrough/ArrowForward.tsx
+++ b/src/components/Walkthrough/ArrowForward.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 const ArrowForward = () => (
   <svg
     width="44"

--- a/src/components/Walkthrough/Walkthrough.tsx
+++ b/src/components/Walkthrough/Walkthrough.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useTheme, useMediaQuery } from "@mui/material";
 import { Box, Container, Stack, Typography } from "@mui/material";
 import ArrowForward from "./ArrowForward";


### PR DESCRIPTION
so they can be composed with RSC in react 18

## Short description
I prendended the `"use client";` directive on each `tsx` file in `/src/components/` directory in order to make these components composable with React Server Components introduced by React 18 (ref: https://react.dev/reference/react/use-client)

## Product
Firma con IO

## How to test
To test the change 