### PR TITLE
SELC-2590-add-topic-label

### DIFF
--- a/src/components/HeaderProduct/HeaderProduct.stories.tsx
+++ b/src/components/HeaderProduct/HeaderProduct.stories.tsx
@@ -141,6 +141,13 @@ const partyList: Array<PartyEntity> = [
     name: "Ente senza stemma",
     productRole: "Referente amministrativo",
   },
+  {
+    id: "14",
+    logoUrl: `${cdnPath}172960361.png`,
+    name: "Amministrazione Comunale",
+    productRole: "Referente amministrativo",
+    topicName: "Comune di Castelfranco Emilia",
+  },
 ];
 
 export const DefaultWithoutParties: ComponentStory<
@@ -218,6 +225,21 @@ export const WithProductSelectionWithPartySelectionWithChip: ComponentStory<
     chipLabel="Collaudo"
     productsList={productsList}
     partyList={partyList}
+    onSelectedParty={(e) => console.log("Selected Item:", e.name)}
+  />
+);
+
+export const WithProductSelectionWithPartySelectionWithChipWithTopicName: ComponentStory<
+  typeof HeaderProduct
+> = () => (
+  <HeaderProduct
+    borderBottom={3}
+    borderColor={theme.palette.warning.main}
+    chipColor="warning"
+    chipLabel="Collaudo"
+    productsList={productsList}
+    partyList={partyList}
+    partyId={"14"}
     onSelectedParty={(e) => console.log("Selected Item:", e.name)}
   />
 );

--- a/src/components/HeaderProduct/HeaderProduct.stories.tsx
+++ b/src/components/HeaderProduct/HeaderProduct.stories.tsx
@@ -155,7 +155,7 @@ const partyList: Array<PartyEntity> = [
     logoUrl: `${cdnPath}172960361.png`,
     name: "Amministrazione Comunale",
     productRole: "Referente amministrativo",
-    topicName: "Comune di Castelfranco Emilia",
+    parentName: "Comune di Castelfranco Emilia",
   },
 ];
 
@@ -288,7 +288,7 @@ export const WithProductSelectionWithPartySelectionWithChipAndIconFunction: Comp
   />
 );
 
-export const WithProductSelectionWithPartySelectionWithChipWithTopicName: ComponentStory<
+export const WithProductSelectionWithPartySelectionWithChipWithParentName: ComponentStory<
   typeof HeaderProduct
 > = () => (
   <HeaderProduct

--- a/src/components/HeaderProduct/HeaderProduct.tsx
+++ b/src/components/HeaderProduct/HeaderProduct.tsx
@@ -151,6 +151,7 @@ export const HeaderProduct = ({
                 infoContainerSx={{
                   display: { xs: "none", md: "block" },
                 }}
+                topicPartyName={selectedParty.topicName}
               />
             )}
           </Box>

--- a/src/components/HeaderProduct/HeaderProduct.tsx
+++ b/src/components/HeaderProduct/HeaderProduct.tsx
@@ -169,7 +169,7 @@ export const HeaderProduct = ({
                 infoContainerSx={{
                   display: { xs: "none", md: "block" },
                 }}
-                topicPartyName={selectedParty.topicName}
+                parentPartyName={selectedParty.parentName}
               />
             )}
           </Box>

--- a/src/components/PartyAccountItem/PartyAccountItem.stories.tsx
+++ b/src/components/PartyAccountItem/PartyAccountItem.stories.tsx
@@ -90,15 +90,15 @@ const partyMockImages: Array<PartyAccount> = [
     image: `${cdnPath}172960361.png`,
     name: "Amministrazione Comunale",
     role: "Referente amministrativo",
-    topicName: "Comune di Castelfranco Emilia",
+    parentName: "Comune di Castelfranco Emilia",
   },
 ];
 
-const itemWithTopic = {
+const itemWithParentName = {
   image: `${cdnPath}172960361.png`,
   name: "Amministrazione Comunale",
   role: "Referente amministrativo",
-  topicName: "Comune di Castelfranco Emilia",
+  parentName: "Comune di Castelfranco Emilia",
 };
 
 const componentMaxWidth = 500;
@@ -163,7 +163,7 @@ const Template: ComponentStory<typeof PartyAccountItem> = (args) => {
         image={item.image}
         partyName={item.name}
         partyRole={item.role}
-        topicPartyName={item.topicName}
+        parentPartyName={item.parentName}
       />
     </Stack>
   );
@@ -179,11 +179,11 @@ NoWrap.args = {
   noWrap: true,
 };
 
-export const WithTopic: ComponentStory<typeof PartyAccountItem> = () => (
+export const WithParentName: ComponentStory<typeof PartyAccountItem> = () => (
   <PartyAccountItem
-    image={itemWithTopic.image}
-    partyName={itemWithTopic.name}
-    partyRole={itemWithTopic.role}
-    topicPartyName={itemWithTopic.topicName}
+    image={itemWithParentName.image}
+    partyName={itemWithParentName.name}
+    partyRole={itemWithParentName.role}
+    parentPartyName={itemWithParentName.parentName}
   />
 );

--- a/src/components/PartyAccountItem/PartyAccountItem.stories.tsx
+++ b/src/components/PartyAccountItem/PartyAccountItem.stories.tsx
@@ -86,6 +86,12 @@ const partyMockImages: Array<PartyAccount> = [
     interventi per la salvaguardia della laguna di Venezia`,
     role: `Operatore - Operatore API Operatore - Operatore API`,
   },
+  {
+    image: `${cdnPath}172960361.png`,
+    name: "Amministrazione Comunale",
+    role: "Referente amministrativo",
+    topicName: "Comune di Castelfranco Emilia",
+  },
 ];
 
 const componentMaxWidth = 500;
@@ -150,6 +156,7 @@ const Template: ComponentStory<typeof PartyAccountItem> = (args) => {
         image={item.image}
         partyName={item.name}
         partyRole={item.role}
+        topicPartyName={item.topicName}
       />
     </Stack>
   );

--- a/src/components/PartyAccountItem/PartyAccountItem.stories.tsx
+++ b/src/components/PartyAccountItem/PartyAccountItem.stories.tsx
@@ -94,6 +94,13 @@ const partyMockImages: Array<PartyAccount> = [
   },
 ];
 
+const itemWithTopic = {
+  image: `${cdnPath}172960361.png`,
+  name: "Amministrazione Comunale",
+  role: "Referente amministrativo",
+  topicName: "Comune di Castelfranco Emilia",
+};
+
 const componentMaxWidth = 500;
 
 /* Generate random value without repeating values
@@ -171,3 +178,12 @@ export const NoWrap = Template.bind({});
 NoWrap.args = {
   noWrap: true,
 };
+
+export const WithTopic: ComponentStory<typeof PartyAccountItem> = () => (
+  <PartyAccountItem
+    image={itemWithTopic.image}
+    partyName={itemWithTopic.name}
+    partyRole={itemWithTopic.role}
+    topicPartyName={itemWithTopic.topicName}
+  />
+);

--- a/src/components/PartyAccountItem/PartyAccountItem.tsx
+++ b/src/components/PartyAccountItem/PartyAccountItem.tsx
@@ -9,10 +9,11 @@ export type PartyAccount = {
   image: string | undefined;
   name: string;
   role?: string | undefined;
+  topicName?: string;
 };
 export interface PartyAccountItemProps {
   image?: string;
-  /* The name of the party. E.g: "Comune di Roma" */
+  /* The name of the party. E.g: "Comune di Roma". If aoo or uo are present, it will be name of Aoo or Uo */
   partyName: string;
   /* The role of the user. E.g: "Referente amministrativo" */
   partyRole?: string;
@@ -23,10 +24,13 @@ export interface PartyAccountItemProps {
   infoContainerSx?: SxProps;
   /* The number of characters beyond which the multiLine is applied */
   maxCharactersNumberMultiLine?: number;
+  /* The name of the party. E.g: "Comune di Roma" when is visible aoo or uo */
+  topicPartyName?: string;
 }
 
 export const PartyAccountItem = ({
   partyName,
+  topicPartyName,
   partyRole,
   image,
   noWrap = true,
@@ -58,7 +62,14 @@ export const PartyAccountItem = ({
     <Box sx={containerStyle}>
       <Box sx={{ display: "flex", flexDirection: "row" }}>
         {/* Avatar Container */}
-        <PartyAvatar customAlt={partyName} customSrc={image} />
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <PartyAvatar customAlt={partyName} customSrc={image} />
+        </Box>
         {/* Info Container */}
         <Box
           sx={{
@@ -68,6 +79,25 @@ export const PartyAccountItem = ({
             ...infoContainerSx,
           }}
         >
+          {topicPartyName && (
+            <Tooltip arrow title={maxCharacter ? topicPartyName : ""}>
+              <Typography
+                variant="caption"
+                component="h6"
+                color="inherit"
+                sx={{
+                  fontWeight: theme.typography.fontWeightMedium,
+                  lineHeight: 1.25,
+                  ...(maxCharacter && {
+                    ...truncatedText,
+                    WebkitLineClamp: 1,
+                  }),
+                }}
+              >
+                {topicPartyName}
+              </Typography>
+            </Tooltip>
+          )}
           {partyName && (
             <Tooltip arrow title={maxCharacter ? partyName : ""}>
               <Typography

--- a/src/components/PartyAccountItem/PartyAccountItem.tsx
+++ b/src/components/PartyAccountItem/PartyAccountItem.tsx
@@ -86,7 +86,7 @@ export const PartyAccountItem = ({
               <Typography
                 variant="caption"
                 component="h6"
-                color="inherit"
+                color="colorTextPrimary"
                 sx={{
                   fontWeight: theme.typography.fontWeightMedium,
                   lineHeight: 1.25,

--- a/src/components/PartyAccountItem/PartyAccountItem.tsx
+++ b/src/components/PartyAccountItem/PartyAccountItem.tsx
@@ -11,7 +11,7 @@ export type PartyAccount = {
   image: string | undefined;
   name: string;
   role?: string | undefined;
-  topicName?: string;
+  parentName?: string;
 };
 export interface PartyAccountItemProps {
   image?: string;
@@ -27,12 +27,12 @@ export interface PartyAccountItemProps {
   /* The number of characters beyond which the multiLine is applied */
   maxCharactersNumberMultiLine?: number;
   /* Label showed above partyName. */
-  topicPartyName?: string;
+  parentPartyName?: string;
 }
 
 export const PartyAccountItem = ({
   partyName,
-  topicPartyName,
+  parentPartyName,
   partyRole,
   image,
   noWrap = true,
@@ -81,8 +81,8 @@ export const PartyAccountItem = ({
             ...infoContainerSx,
           }}
         >
-          {topicPartyName && (
-            <Tooltip arrow title={maxCharacter ? topicPartyName : ""}>
+          {parentPartyName && (
+            <Tooltip arrow title={maxCharacter ? parentPartyName : ""}>
               <Typography
                 variant="caption"
                 component="h6"
@@ -96,7 +96,7 @@ export const PartyAccountItem = ({
                   }),
                 }}
               >
-                {topicPartyName}
+                {parentPartyName}
               </Typography>
             </Tooltip>
           )}

--- a/src/components/PartyAccountItem/PartyAccountItem.tsx
+++ b/src/components/PartyAccountItem/PartyAccountItem.tsx
@@ -15,7 +15,7 @@ export type PartyAccount = {
 };
 export interface PartyAccountItemProps {
   image?: string;
-  /* The name of the party. E.g: "Comune di Roma". If aoo or uo are present, it will be name of Aoo or Uo */
+  /* The name of the party. E.g: "Comune di Roma".  */
   partyName: string;
   /* The role of the user. E.g: "Referente amministrativo" */
   partyRole?: string;
@@ -26,7 +26,7 @@ export interface PartyAccountItemProps {
   infoContainerSx?: SxProps;
   /* The number of characters beyond which the multiLine is applied */
   maxCharactersNumberMultiLine?: number;
-  /* The name of the party. E.g: "Comune di Roma" when is visible aoo or uo */
+  /* Label showed above partyName. */
   topicPartyName?: string;
 }
 

--- a/src/components/PartyAccountItemButton/PartyAccountItemButton.stories.tsx
+++ b/src/components/PartyAccountItemButton/PartyAccountItemButton.stories.tsx
@@ -96,9 +96,15 @@ const partyMockImages: Array<PartyAccount> = [
   },
 ];
 
+const itemWithTopic = {
+  image: `${cdnPath}172960361.png`,
+  name: "Amministrazione Comunale",
+  role: "Referente amministrativo",
+  topicName: "Comune di Castelfranco Emilia",
+};
+
 /* Tag Element */
 const tag: JSX.Element = <Tag color="warning" value="Da completare" />;
-
 const componentMaxWidth = 400;
 
 /* Generate random value without repeating values
@@ -173,3 +179,12 @@ export const WithTag = Template.bind({});
 WithTag.args = {
   endSlot: tag,
 };
+
+export const WithTopic: ComponentStory<typeof PartyAccountItemButton> = () => (
+  <PartyAccountItemButton
+    image={itemWithTopic.image}
+    partyName={itemWithTopic.name}
+    partyRole={itemWithTopic.role}
+    topicPartyName={itemWithTopic.topicName}
+  />
+);

--- a/src/components/PartyAccountItemButton/PartyAccountItemButton.stories.tsx
+++ b/src/components/PartyAccountItemButton/PartyAccountItemButton.stories.tsx
@@ -92,15 +92,15 @@ const partyMockImages: Array<PartyAccount> = [
     image: `${cdnPath}172960361.png`,
     name: "Amministrazione Comunale",
     role: "Referente amministrativo",
-    topicName: "Comune di Castelfranco Emilia",
+    parentName: "Comune di Castelfranco Emilia",
   },
 ];
 
-const itemWithTopic = {
+const itemWithParentName = {
   image: `${cdnPath}172960361.png`,
   name: "Amministrazione Comunale",
   role: "Referente amministrativo",
-  topicName: "Comune di Castelfranco Emilia",
+  parentName: "Comune di Castelfranco Emilia",
 };
 
 /* Tag Element */
@@ -156,7 +156,7 @@ const Template: ComponentStory<typeof PartyAccountItemButton> = (args) => {
         image={item.image}
         partyName={item.name}
         partyRole={item.role}
-        topicPartyName={item.topicName}
+        parentPartyName={item.parentName}
       />
     </Stack>
   );
@@ -180,11 +180,13 @@ WithTag.args = {
   endSlot: tag,
 };
 
-export const WithTopic: ComponentStory<typeof PartyAccountItemButton> = () => (
+export const WithParentName: ComponentStory<
+  typeof PartyAccountItemButton
+> = () => (
   <PartyAccountItemButton
-    image={itemWithTopic.image}
-    partyName={itemWithTopic.name}
-    partyRole={itemWithTopic.role}
-    topicPartyName={itemWithTopic.topicName}
+    image={itemWithParentName.image}
+    partyName={itemWithParentName.name}
+    partyRole={itemWithParentName.role}
+    parentPartyName={itemWithParentName.parentName}
   />
 );

--- a/src/components/PartyAccountItemButton/PartyAccountItemButton.stories.tsx
+++ b/src/components/PartyAccountItemButton/PartyAccountItemButton.stories.tsx
@@ -88,6 +88,12 @@ const partyMockImages: Array<PartyAccount> = [
     interventi per la salvaguardia della laguna di Venezia`,
     role: `Operatore - Operatore API Operatore - Operatore API`,
   },
+  {
+    image: `${cdnPath}172960361.png`,
+    name: "Amministrazione Comunale",
+    role: "Referente amministrativo",
+    topicName: "Comune di Castelfranco Emilia",
+  },
 ];
 
 /* Tag Element */
@@ -144,6 +150,7 @@ const Template: ComponentStory<typeof PartyAccountItemButton> = (args) => {
         image={item.image}
         partyName={item.name}
         partyRole={item.role}
+        topicPartyName={item.topicName}
       />
     </Stack>
   );

--- a/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
+++ b/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
@@ -10,7 +10,7 @@ import { theme } from "@theme";
 
 export interface PartyAccountItemButtonProps {
   selectedItem?: boolean;
-  /* The name of the party. E.g: "Comune di Roma". If aoo or uo are present, it will be name of Aoo or Uo */
+  /* The name of the party. E.g: "Comune di Roma".  */
   partyName: string;
   /* The role of the user. E.g: "Referente amministrativo" */
   partyRole?: string;
@@ -21,7 +21,7 @@ export interface PartyAccountItemButtonProps {
   endSlot?: JSX.Element | Array<JSX.Element> | undefined;
   /* The number of characters beyond which the multiLine is applied */
   maxCharactersNumberMultiLine?: number;
-  /* The name of the party. E.g: "Comune di Roma" when is visible aoo or uo */
+  /* Label showed above partyName. */
   topicPartyName?: string;
 }
 
@@ -33,7 +33,7 @@ export const PartyAccountItemButton = ({
   action,
   disabled,
   endSlot,
-  maxCharactersNumberMultiLine = 5,
+  maxCharactersNumberMultiLine = 50,
   topicPartyName,
 }: PartyAccountItemButtonProps) => {
   const maxCharacter =

--- a/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
+++ b/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
@@ -8,7 +8,7 @@ import { theme } from "@theme";
 
 export interface PartyAccountItemButtonProps {
   selectedItem?: boolean;
-  /* The name of the party. E.g: "Comune di Roma" */
+  /* The name of the party. E.g: "Comune di Roma". If aoo or uo are present, it will be name of Aoo or Uo */
   partyName: string;
   /* The role of the user. E.g: "Referente amministrativo" */
   partyRole?: string;
@@ -19,6 +19,8 @@ export interface PartyAccountItemButtonProps {
   endSlot?: JSX.Element | Array<JSX.Element> | undefined;
   /* The number of characters beyond which the multiLine is applied */
   maxCharactersNumberMultiLine?: number;
+  /* The name of the party. E.g: "Comune di Roma" when is visible aoo or uo */
+  topicPartyName?: string;
 }
 
 export const PartyAccountItemButton = ({
@@ -29,7 +31,8 @@ export const PartyAccountItemButton = ({
   action,
   disabled,
   endSlot,
-  maxCharactersNumberMultiLine = 50,
+  maxCharactersNumberMultiLine = 5,
+  topicPartyName,
 }: PartyAccountItemButtonProps) => {
   const maxCharacter =
     partyName && partyName.length > maxCharactersNumberMultiLine;
@@ -78,6 +81,8 @@ export const PartyAccountItemButton = ({
             ...(disabled && {
               opacity: theme.palette.action.disabledOpacity,
             }),
+            display: "flex",
+            alignItems: "center",
           }}
         >
           <PartyAvatar customAlt={partyName} customSrc={image} />
@@ -94,6 +99,25 @@ export const PartyAccountItemButton = ({
             }),
           }}
         >
+          {topicPartyName && (
+            <Tooltip arrow title={maxCharacter ? topicPartyName : ""}>
+              <Typography
+                variant="caption"
+                component="h6"
+                color="inherit"
+                sx={{
+                  fontWeight: theme.typography.fontWeightMedium,
+                  lineHeight: 1.25,
+                  ...(maxCharacter && {
+                    ...truncatedText,
+                    WebkitLineClamp: 1,
+                  }),
+                }}
+              >
+                {topicPartyName}
+              </Typography>
+            </Tooltip>
+          )}
           {partyName && (
             <Tooltip arrow title={maxCharacter ? partyName : ""}>
               <Typography

--- a/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
+++ b/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
@@ -22,7 +22,7 @@ export interface PartyAccountItemButtonProps {
   /* The number of characters beyond which the multiLine is applied */
   maxCharactersNumberMultiLine?: number;
   /* Label showed above partyName. */
-  topicPartyName?: string;
+  parentPartyName?: string;
 }
 
 export const PartyAccountItemButton = ({
@@ -34,7 +34,7 @@ export const PartyAccountItemButton = ({
   disabled,
   endSlot,
   maxCharactersNumberMultiLine = 50,
-  topicPartyName,
+  parentPartyName,
 }: PartyAccountItemButtonProps) => {
   const maxCharacter =
     partyName && partyName.length > maxCharactersNumberMultiLine;
@@ -101,8 +101,8 @@ export const PartyAccountItemButton = ({
             }),
           }}
         >
-          {topicPartyName && (
-            <Tooltip arrow title={maxCharacter ? topicPartyName : ""}>
+          {parentPartyName && (
+            <Tooltip arrow title={maxCharacter ? parentPartyName : ""}>
               <Typography
                 variant="caption"
                 component="h6"
@@ -116,7 +116,7 @@ export const PartyAccountItemButton = ({
                   }),
                 }}
               >
-                {topicPartyName}
+                {parentPartyName}
               </Typography>
             </Tooltip>
           )}

--- a/src/components/PartySwitch/PartySwitch.tsx
+++ b/src/components/PartySwitch/PartySwitch.tsx
@@ -35,7 +35,7 @@ export type PartySwitchItem = {
   name: string;
   productRole?: string;
   logoUrl?: string;
-  topicName?: string;
+  parentName?: string;
 };
 
 export type PartySwitchProps = {
@@ -126,7 +126,7 @@ export const PartySwitch = ({
           image={selectedParty.logoUrl}
           infoContainerSx={mobileHideStyle}
           maxCharactersNumberMultiLine={maxCharactersNumberMultiLineItem}
-          topicPartyName={selectedParty?.topicName}
+          parentPartyName={selectedParty?.parentName}
         />
         {open ? (
           <ArrowDropUpRoundedIcon sx={mobileHideStyle} />
@@ -190,7 +190,7 @@ export const PartySwitch = ({
               action={() => handlePartySelection(e)}
               selectedItem={e.id === selectedId}
               maxCharactersNumberMultiLine={maxCharactersNumberMultiLineButton}
-              topicPartyName={e.topicName}
+              parentPartyName={e.parentName}
             />
           ))}
         {filteredParties.length === 0 && (

--- a/src/components/PartySwitch/PartySwitch.tsx
+++ b/src/components/PartySwitch/PartySwitch.tsx
@@ -33,6 +33,7 @@ export type PartySwitchItem = {
   name: string;
   productRole?: string;
   logoUrl?: string;
+  topicName?: string;
 };
 
 export type PartySwitchProps = {
@@ -123,6 +124,7 @@ export const PartySwitch = ({
           image={selectedParty.logoUrl}
           infoContainerSx={mobileHideStyle}
           maxCharactersNumberMultiLine={maxCharactersNumberMultiLineItem}
+          topicPartyName={selectedParty?.topicName}
         />
         {open ? (
           <ArrowDropUpRoundedIcon sx={mobileHideStyle} />
@@ -186,6 +188,7 @@ export const PartySwitch = ({
               action={() => handlePartySelection(e)}
               selectedItem={e.id === selectedId}
               maxCharactersNumberMultiLine={maxCharactersNumberMultiLineButton}
+              topicPartyName={e.topicName}
             />
           ))}
         {filteredParties.length === 0 && (


### PR DESCRIPTION
## Short description

change the PartyAccountItemButton and PartyAccountItem components adding an optional label above party title.

### Preview
![image](https://github.com/pagopa/mui-italia/assets/92723520/7de46f99-94f8-49d2-ac98-2f991b41aece)

## List of changes proposed in this pull request
- added in PartyAccountItemButton component (and its parent components) property: topicPartyName 
- added in PartyAccountItem component (and its parent components) property: topicPartyName
- modified PartySwitchItem type adding property: topicPartyName 

## Product
Area Riservata.

## How to test
go to storyBook and on story/components-partyaccountitembutton--with-tag or story/components-partyaccountitem--with-topic.