### PR TITLE
[IOPID-1083] fix console warning "dangerouslySetInnerHTML"

### DIFF
--- a/src/utils/ts-utils.ts
+++ b/src/utils/ts-utils.ts
@@ -27,7 +27,7 @@ export function createEnumType<T>(e: object, name?: string) {
   return new EnumType<T>(e, name);
 }
 
-export const hrefNoOp = "javascript:void(0)";
+export const hrefNoOp = "#!";
 export const wrapHandleExitAction =
   (
     href: string,


### PR DESCRIPTION
## Short description
To the present day, when using the footer exported from MUI-Italy, if we do not use the href or set it as undefined in the console, the warning shown this warning: 
<img width="400" alt="Screenshot 2023-10-26 alle 16 12 55" src="https://github.com/pagopa/mui-italia/assets/83651704/bbe935f7-11f5-49d8-bf5c-84bec87c4592">


## List of changes proposed in this pull request
- Change from `"javascript:void(0)"` to `"#!"` in [this file](https://github.com/pagopa/mui-italia/blob/c434224ddb20f7caf193e3fb1442f23e66628e25/src/utils/ts-utils.ts#L30)

## Product
This small bug was found by the Authentication and Identity team during the development of io-web-profiles

## How to test
This solution can also be tested by running the storybook. Watching in the console when viewing the Footer no longer displays the Warning