### PR TITLE
fixed assistence icon color while changing viewport

### DIFF
--- a/src/components/HeaderAccount/HeaderAccount.tsx
+++ b/src/components/HeaderAccount/HeaderAccount.tsx
@@ -133,7 +133,7 @@ export const HeaderAccount = ({
               <IconButton
                 size="small"
                 aria-label="Assistenza"
-                sx={{ display: ["flex", "none"] }}
+                sx={{ display: ["flex", "none"], color: "text.primary" }}
                 onClick={onAssistanceClick}
               >
                 <HelpOutlineRoundedIcon fontSize="inherit" />


### PR DESCRIPTION
## Short description
The assistance icon wasn't shown in the proper color while changing the viewport. 

### Preview
[ref](https://pagopa.atlassian.net/browse/PN-6687?atlOrigin=eyJpIjoiMzUwZTY0M2Y3NDFmNGY5ZGIxMzZhODFiMzVkYTkzZWMiLCJwIjoiaiJ9)

## List of changes proposed in this pull request
- added `color` property with value: `text.primary` in order to stick with the color while changing thje viewport.

## Product
Piattaforma Notifiche

## How to test
Just run `yarn storybook` and select the HeaderAccount component. Check if the assistance icon stays the same color while changing viewport.