### PR TITLE
PN-7135-mui-italia-ds-bug-ui-mittente-pagina-dettaglio-di-una-notifica-mobile

### DIFF
--- a/src/components/TimelineNotification/TimelineNotification.tsx
+++ b/src/components/TimelineNotification/TimelineNotification.tsx
@@ -13,6 +13,7 @@ export const TimelineNotification: React.FC<TimelineProps> = (
       sx={{
         px: "0",
         py: theme.spacing(2),
+        ...props.sx,
       }}
     >
       {children}

--- a/src/components/TimelineNotification/TimelineNotificationContent.tsx
+++ b/src/components/TimelineNotification/TimelineNotificationContent.tsx
@@ -15,6 +15,7 @@ export const TimelineNotificationContent: React.FC<TimelineContentProps> = (
         py: 0,
         px: theme.spacing(2.5),
         my: theme.spacing(2.5),
+        ...props.sx,
       }}
     >
       <Stack spacing={1} alignItems="baseline">

--- a/src/components/TimelineNotification/TimelineNotificationDot.tsx
+++ b/src/components/TimelineNotification/TimelineNotificationDot.tsx
@@ -19,6 +19,7 @@ export const TimelineNotificationDot: React.FC<TimelineNotificationDotProps> = (
         my: theme.spacing(0.5),
         padding: size === "small" ? "1px" : "4px",
         alignSelf: "center",
+        ...props.sx,
       }}
     >
       {children}

--- a/src/components/TimelineNotification/TimelineNotificationItem.tsx
+++ b/src/components/TimelineNotification/TimelineNotificationItem.tsx
@@ -10,15 +10,14 @@ export const TimelineNotificationItem: React.FC<TimelineItemProps> = (
 
   return (
     <TimelineItem
-      sx={[
-        {
-          /* Remove extra space because there's opposite content, but the relative
+      sx={{
+        /* Remove extra space because there's opposite content, but the relative
           prop is not exposed by the component's API */
-          "&:before": {
-            display: "none",
-          },
+        "&:before": {
+          display: "none",
         },
-      ]}
+        ...props.sx,
+      }}
     >
       {children}
     </TimelineItem>

--- a/src/components/TimelineNotification/TimelineNotificationOppositeContent.tsx
+++ b/src/components/TimelineNotification/TimelineNotificationOppositeContent.tsx
@@ -8,29 +8,31 @@ import {
 import { Box } from "@mui/material";
 import { theme } from "@theme";
 
-export const TimelineNotificationOppositeContent: React.FC<TimelineOppositeContentProps> =
-  (props): React.ReactElement => {
-    const { children } = props;
-    return (
-      <TimelineOppositeContent
+export const TimelineNotificationOppositeContent: React.FC<
+  TimelineOppositeContentProps
+> = (props): React.ReactElement => {
+  const { children } = props;
+  return (
+    <TimelineOppositeContent
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "end",
+        flex: "15% 0",
+        p: "0",
+        pr: theme.spacing(2.5),
+        ...props.sx,
+      }}
+    >
+      <Box
         sx={{
           display: "flex",
-          alignItems: "center",
-          justifyContent: "end",
-          flex: "15% 0",
-          p: "0",
-          pr: theme.spacing(2.5),
+          flexDirection: "column",
+          textAlign: "center",
         }}
       >
-        <Box
-          sx={{
-            display: "flex",
-            flexDirection: "column",
-            textAlign: "center",
-          }}
-        >
-          {children}
-        </Box>
-      </TimelineOppositeContent>
-    );
-  };
+        {children}
+      </Box>
+    </TimelineOppositeContent>
+  );
+};

--- a/src/components/TimelineNotification/TimelineNotificationSeparator.tsx
+++ b/src/components/TimelineNotification/TimelineNotificationSeparator.tsx
@@ -12,6 +12,7 @@ export const TimelineNotificationSeparator: React.FC<TimelineSeparatorProps> = (
     <TimelineSeparator
       sx={{
         minWidth: "12px",
+        ...props.sx,
       }}
     >
       {children}

--- a/src/utils/ts-utils.ts
+++ b/src/utils/ts-utils.ts
@@ -27,7 +27,7 @@ export function createEnumType<T>(e: object, name?: string) {
   return new EnumType<T>(e, name);
 }
 
-export const hrefNoOp = "javascript:void(0)";
+export const hrefNoOp = "#!";
 export const wrapHandleExitAction =
   (
     href: string,


### PR DESCRIPTION
## Short description
Added the ability to pass props using `...props.sx`.


### Preview
[ref](https://pagopa.atlassian.net/browse/PN-7135?atlOrigin=eyJpIjoiYmE1NWJhMTc3YjRlNDRhY2EyNjk1MjM2MzU1NGU1MzgiLCJwIjoiaiJ9)

## List of changes proposed in this pull request
- Modified `TimelineNotification.tsx` and `TimelineNotification.tsx` to allow passing props using `...props.sx`.


## Product
Piattaforma Notifiche

## How to test
There isn't a definitive way to test it as it needs to be used within the project, by adding new parameters, to ensure their correct application.
