### PR TITLE
fix: ProductSwitch is now correctly showing the selected product

### DIFF
--- a/src/components/ProductSwitch/ProductSwitch.tsx
+++ b/src/components/ProductSwitch/ProductSwitch.tsx
@@ -51,7 +51,7 @@ export const ProductSwitch = ({
   );
 
   useEffect(() => {
-    setSelectedId(selectedId);
+    setSelectedId(currentProductId);
   }, [currentProductId]);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
## Short description
When opening the product selection dropdown, the current product is not correctly selected (menu item not highlighted in blue).

### Preview
[ref](https://pagopa.atlassian.net/browse/PN-8759?atlOrigin=eyJpIjoiZDBkMmQ4NzYzNmJjNDgzZWE0ZjdmZWUyYzBjNjE4YWUiLCJwIjoiaiJ9)

## List of changes proposed in this pull request
- updated the state by setting `currentProductId` instead of `selectedId`. Previously, there was an issue where `selectedId` was being reassigned to itself without any changes.

## Product
Piattaforma Notifiche

## How to test
Just test it within the project or in the storybook and try to change the product.