### PR TITLE
Updated EnvironmentBanner prop to pass background color to ribbon

### DIFF
--- a/src/components/EnvironmentBanner/EnvironmentBanner.stories.tsx
+++ b/src/components/EnvironmentBanner/EnvironmentBanner.stories.tsx
@@ -16,12 +16,11 @@ export default {
     },
   },
   argTypes: {
-    env: {
+    bgColor: {
       control: {
         type: "radio",
-        options: ["test", "prod"],
+        options: ["info", "warning"],
       },
-      defaultValue: "test",
     },
     message: {
       control: {
@@ -43,3 +42,6 @@ export const Default: ComponentStory<typeof EnvironmentBanner> = (args) => (
     icon={<WarningAmberIcon fontSize="small" />}
   />
 );
+Default.args = {
+  bgColor: "info",
+};

--- a/src/components/EnvironmentBanner/EnvironmentBanner.tsx
+++ b/src/components/EnvironmentBanner/EnvironmentBanner.tsx
@@ -3,38 +3,35 @@
 import React from "react";
 import { Alert, Typography } from "@mui/material";
 export interface EnvironmentBannerProps {
-  env: "test" | "prod";
+  bgColor: "warning" | "info";
   message: string;
   icon?: React.ReactNode;
 }
 
 export const EnvironmentBanner = ({
-  env,
+  bgColor,
   message,
   icon,
-}: EnvironmentBannerProps) => {
-  const bgcolor = env === "test" ? "warning.extraLight" : "background.default";
-  return (
-    <Alert
-      sx={{
-        borderLeft: "none",
-        borderRadius: 0,
-        alignItems: "center",
-        justifyContent: "center",
-        bgcolor,
-        "&.MuiPaper-root": {
-          px: { xs: 1, sm: 3 },
-          py: 1,
-        },
-      }}
-      icon={icon ?? false}
+}: EnvironmentBannerProps) => (
+  <Alert
+    sx={{
+      borderLeft: "none",
+      borderRadius: 0,
+      alignItems: "center",
+      justifyContent: "center",
+      bgcolor: `${bgColor}.extraLight`,
+      "&.MuiPaper-root": {
+        px: { xs: 1, sm: 3 },
+        py: 1,
+      },
+    }}
+    icon={icon ?? false}
+  >
+    <Typography
+      variant="body2"
+      sx={{ maxWidth: 480, textAlign: "center", wordBreak: "break-word" }}
     >
-      <Typography
-        variant="body2"
-        sx={{ maxWidth: 480, textAlign: "center", wordBreak: "break-word" }}
-      >
-        {message}
-      </Typography>
-    </Alert>
-  );
-};
+      {message}
+    </Typography>
+  </Alert>
+);


### PR DESCRIPTION
## Short description
Instead of passing the environment, one should pass the color key (`info` or `warning`) to generate the appropriate color. This is an intermediate PR. The next one will give the opportunity to pass in any color in the MUI Italia palette. This is due to updated requirements in Interoperabilità after the introduction of the "Ambiente di attestazione" product.

## Product
Interoperabilità

## Before
One would pass the `env` property (`test` or `prod`) to set the ribbon background color

## After
One would pass the `bgColor` property (`info` or `warning`) to set the ribbon background color