### PR TITLE
fix(PN-10793): increase padding to MuiLink

### DIFF
--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -25,6 +25,7 @@ const colorPrimaryContainedHover = "#0055AA"; // Not exposed by the theme object
 const responsiveBreakpoint = "sm";
 export const ringWidth = "4px";
 const marginLinkSize = "4px";
+const paddingLinkSize = "1px";
 export const focusWidth = "2px";
 export const focusBorderRadius = "8px";
 export const focusOffset = "4px";
@@ -1127,7 +1128,8 @@ export const theme: Theme = createTheme(foundation, {
           "&.MuiTypography-root": {
             marginTop: `${marginLinkSize}`,
             marginBottom: `${marginLinkSize}`,
-            padding: 0,
+            paddingTop: `${paddingLinkSize}`,
+            paddingBottom: `${paddingLinkSize}`,
           },
           "&.Mui-focusVisible": {
             borderRadius: `${focusBorderRadius}`,


### PR DESCRIPTION
## Short description
increase padding to MuiLink to make it as nearest as possible to minimum 24x target size.


## List of changes proposed in this pull request
-  Add 1px padding top to MuiLink
-  Add 1px padding bottom to MuiLink

## Product
Piattaforma Notifiche -> SEND

## How to test
Run storybook and check Links are minimum 23,97px.