### PR TITLE
[SELC-4552] Feat: update styles for Tag and Chip components

### DIFF
--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -41,19 +41,18 @@ export const Tag = ({
   variant = "default",
   ...rest
 }: TagProps): JSX.Element => {
-  const tagNeutralBg =
-    variant === "light" ? theme.palette.grey[100] : theme.palette.grey[200];
+  const tagNeutralBg = variant === theme.palette.grey[100];
   const tagBgColor =
     color !== "default"
       ? variant === "light"
-        ? alpha(theme.palette[color].main, 0.1)
-        : theme.palette[color].main
+        ? alpha(theme.palette[color][100], 0.1)
+        : theme.palette[color][100]
       : tagNeutralBg;
 
   const tagTextColor =
-    variant === "default" && color === "primary"
-      ? theme.palette.primary.contrastText
-      : theme.palette.text.primary;
+    color === "default" || color === "primary"
+      ? theme.palette.text.primary
+      : theme.palette[color][850];
 
   return (
     <StyledTag

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -41,7 +41,7 @@ export const Tag = ({
   variant = "default",
   ...rest
 }: TagProps): JSX.Element => {
-  const tagNeutralBg = variant === theme.palette.grey[100];
+  const tagNeutralBg = theme.palette.grey[100];
   const tagBgColor =
     color !== "default"
       ? variant === "light"

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -106,8 +106,8 @@ declare module "@mui/material/styles" {
 
   interface PaletteColor {
     extraLight?: string;
-    100?: string;
-    850?: string;
+    100: string;
+    850: string;
   }
 
   /* Add new extraLight key to the colours */

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -106,6 +106,8 @@ declare module "@mui/material/styles" {
 
   interface PaletteColor {
     extraLight?: string;
+    100?: string;
+    850?: string;
   }
 
   /* Add new extraLight key to the colours */

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -115,6 +115,8 @@ declare module "@mui/material/styles" {
     light?: string;
     contrastText?: string;
     extraLight?: string;
+    100?: string;
+    850?: string;
   }
 }
 
@@ -210,6 +212,7 @@ const foundation: Theme = createTheme({
       light: "#2185E9",
       dark: "#0062C3",
       contrastText: "#FFFFFF",
+      100: "#C4DCF5",
     },
     secondary: {
       main: "#00C5CA",
@@ -264,6 +267,8 @@ const foundation: Theme = createTheme({
       light: "#FE7A7A",
       extraLight: "#FB9EAC",
       contrastText: colorTextPrimary,
+      100: "#FFE0E0",
+      850: "#761F1F",
     },
     info: {
       main: "#6BCFFB",
@@ -271,6 +276,8 @@ const foundation: Theme = createTheme({
       light: "#7ED5FC",
       extraLight: "#86E1FD",
       contrastText: colorTextPrimary,
+      100: "#E1F5FE",
+      850: "#215C76",
     },
     success: {
       main: "#6CC66A",
@@ -278,6 +285,8 @@ const foundation: Theme = createTheme({
       light: "#7FCD7D",
       extraLight: "#B5E2B4",
       contrastText: colorTextPrimary,
+      100: "#E1F4E1",
+      850: "#224021",
     },
     warning: {
       main: "#FFCB46",
@@ -285,6 +294,8 @@ const foundation: Theme = createTheme({
       light: "#FFD25E",
       extraLight: "#FFE5A3",
       contrastText: colorTextPrimary,
+      100: "#FFF5DA",
+      850: "#614C15",
     },
   },
   typography: {
@@ -835,61 +846,107 @@ export const theme: Theme = createTheme(foundation, {
         },
         outlined: {
           borderRadius: foundation.spacing(5),
+          "&.MuiChip-outlinedDefault": {
+            color: colorTextPrimary,
+            borderColor: "#0000003B",
+            "& .MuiChip-avatar": {
+              backgroundColor: foundation.palette.grey[400],
+              color: "#17324D",
+            },
+          },
+          "&.MuiChip-outlinedPrimary": {
+            color: colorTextPrimary,
+            borderColor: colorTextPrimary,
+          },
         },
-        colorSecondary: {
-          "&.MuiChip-filled": {
+        filled: {
+          "&.MuiChip-colorDefault": {
+            backgroundColor: foundation.palette.grey[200],
+            color: foundation.palette.text.primary,
+          },
+          "&.MuiChip-colorPrimary": {
+            backgroundColor: foundation.palette.primary[100],
+            color: colorTextPrimary,
+          },
+          "&.MuiChip-colorSecondary": {
             backgroundColor: alpha(foundation.palette.secondary.main, 0.5),
             color: foundation.palette.text.primary,
           },
+          "&.MuiChip-colorInfo": {
+            backgroundColor: foundation.palette.info[100],
+            color: foundation.palette.info[850],
+          },
+          "&.MuiChip-colorError": {
+            backgroundColor: foundation.palette.error[100],
+            color: foundation.palette.error[850],
+          },
+          "&.MuiChip-colorSuccess": {
+            backgroundColor: foundation.palette.success[100],
+            color: foundation.palette.success[850],
+          },
+          "&.MuiChip-colorWarning": {
+            backgroundColor: foundation.palette.warning[100],
+            color: foundation.palette.warning[850],
+          },
+        },
+        colorDefault: {
+          "& .MuiChip-avatar": {
+            backgroundColor: foundation.palette.grey[400],
+            color: foundation.palette.grey[700],
+          },
+          "& .MuiChip-deleteIcon": {
+            color: alpha(foundation.palette.text.primary, 0.23),
+          },
+        },
+        colorPrimary: {
+          "& .MuiChip-avatar": {
+            backgroundColor: foundation.palette.primary.light,
+            color: foundation.palette.primary.contrastText,
+          },
+          "& .MuiChip-deleteIcon": {
+            color: colorTextPrimary,
+          },
+        },
+        colorSecondary: {
+          "& .MuiChip-deleteIcon": {
+            color: colorTextPrimary,
+          },
         },
         colorInfo: {
-          "&.MuiChip-filled": {
+          "& .MuiChip-avatar": {
             backgroundColor: foundation.palette.info.light,
-            /* color: foundation.palette.text.primary, */
+            color: foundation.palette.info[850],
           },
-          /* "& .MuiChip-avatar": {
-            backgroundColor: foundation.palette.info.dark,
-            color: foundation.palette.info.contrastText,
-          }, */
+          "& .MuiChip-deleteIcon": {
+            color: foundation.palette.info[850],
+          },
         },
         colorError: {
-          "&.MuiChip-filled": {
+          "& .MuiChip-avatar": {
             backgroundColor: foundation.palette.error.light,
-            /*  color: foundation.palette.text.primary, */
-            /* color: foundation.palette.getContrastText(
-              foundation.palette.error.extraLight as string
-            ), */
+            color: foundation.palette.error[850],
           },
-          /* "& .MuiChip-avatar": {
-            backgroundColor: foundation.palette.error.dark,
-            color: foundation.palette.error.contrastText,
-          }, */
+          "& .MuiChip-deleteIcon": {
+            color: foundation.palette.error[850],
+          },
         },
         colorSuccess: {
-          "&.MuiChip-filled": {
+          "& .MuiChip-avatar": {
             backgroundColor: foundation.palette.success.light,
-            /* color: foundation.palette.text.primary, */
-            /* color: foundation.palette.getContrastText(
-              foundation.palette.success.extraLight as string
-            ), */
+            color: foundation.palette.success[850],
           },
-          /* "& .MuiChip-avatar": {
-            backgroundColor: foundation.palette.success.dark,
-            color: foundation.palette.success.contrastText,
-          }, */
+          "& .MuiChip-deleteIcon": {
+            color: foundation.palette.success[850],
+          },
         },
         colorWarning: {
-          "&.MuiChip-filled": {
+          "& .MuiChip-avatar": {
             backgroundColor: foundation.palette.warning.light,
-            /* color: foundation.palette.text.primary, */
-            /* color: foundation.palette.getContrastText(
-              foundation.palette.warning.extraLight as string
-            ), */
+            color: foundation.palette.warning[850],
           },
-          /* "& .MuiChip-avatar": {
-            backgroundColor: foundation.palette.warning.dark,
-            color: foundation.palette.warning.contrastText,
-          }, */
+          "& .MuiChip-deleteIcon": {
+            color: foundation.palette.warning[850],
+          },
         },
       },
     },


### PR DESCRIPTION
## Short description
To ensure greater accessibility, the colors of chips and tags have been modified.

### Preview
If it makes sense, please add one or more screenshots/videos.

## List of changes proposed in this pull request
- Customization of the outlined variant for the default and primary chips.
- Specific styles for the outlined default chip, including border color, avatar background color, and text color.
- Consolidation and simplification of shared styles across different color variants.

## Product
Please specify what product from which this feature originated (e.g: Piattaforma Notifiche, Area Riservata, etc…). Leave blank if it's not referred specifically to a single product.

Area Riservata (Selfcare)

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
npm run storybook and go to chips and tag component. Make sure colors are as designed in here
https://www.figma.com/file/pNBaYInnJjgyg1BZ1VeuJq/MUI-Italia---Design-System?type=design&node-id=13346%3A34509&mode=design&t=oL3vSPW3ty0xM5Vr-1