### PR TITLE
[SELC-4585] Feat: adapt drawer component to responsive design

### DIFF
--- a/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
+++ b/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
@@ -128,7 +128,7 @@ export const PartyAccountItemButton = ({
                 component="h6"
                 color="inherit"
                 sx={{
-                  fontWeight: "600",
+                  fontWeight: theme.typography.fontWeightMedium,
                   lineHeight: 1.25,
                   ...(maxCharacter && {
                     ...truncatedText,

--- a/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
+++ b/src/components/PartyAccountItemButton/PartyAccountItemButton.tsx
@@ -49,7 +49,8 @@ export const PartyAccountItemButton = ({
   return (
     <Box
       sx={{
-        p: 1.5,
+        py: 2,
+        px: 3,
         width: "100%",
         backgroundColor: "background.paper",
         color: "text.primary",
@@ -66,7 +67,7 @@ export const PartyAccountItemButton = ({
         ...(selectedItem && {
           boxShadow: `inset 2px 0 0 0 ${theme.palette.primary.main}`,
           backgroundColor: theme.palette.primaryAction.selected,
-          color: theme.palette.primary.main,
+          color: theme.palette.text.primary,
           "&:hover": {
             backgroundColor: theme.palette.primaryAction.hover,
           },
@@ -127,7 +128,7 @@ export const PartyAccountItemButton = ({
                 component="h6"
                 color="inherit"
                 sx={{
-                  fontWeight: theme.typography.fontWeightBold,
+                  fontWeight: "600",
                   lineHeight: 1.25,
                   ...(maxCharacter && {
                     ...truncatedText,

--- a/src/components/PartySwitch/PartySwitch.tsx
+++ b/src/components/PartySwitch/PartySwitch.tsx
@@ -1,37 +1,37 @@
 "use client";
 
-import {
-  ChangeEvent,
-  ForwardedRef,
-  forwardRef,
-  Fragment,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
-import clsx from "clsx";
-import { ringWidth, theme } from "@theme";
+import { ButtonProps } from "@mui/base/Button";
+import { useButton } from "@mui/base/useButton";
 import {
   Box,
   Button,
   Drawer,
+  IconButton,
   InputAdornment,
   TextField,
   Typography,
-  IconButton,
 } from "@mui/material";
 import { alpha, styled } from "@mui/material/styles";
-import { ButtonProps } from "@mui/base/Button";
-import { useButton } from "@mui/base/useButton";
-
-import SearchIcon from "@mui/icons-material/Search";
-import ArrowDropUpRoundedIcon from "@mui/icons-material/ArrowDropUpRounded";
-import ArrowDropDownRoundedIcon from "@mui/icons-material/ArrowDropDownRounded";
-import SentimentDissatisfied from "@mui/icons-material/SentimentDissatisfied";
-import CloseIcon from "@mui/icons-material/Close";
+import { ringWidth, theme } from "@theme";
+import clsx from "clsx";
+import {
+  ChangeEvent,
+  ForwardedRef,
+  Fragment,
+  forwardRef,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import { PartyAccountItem } from "@components/PartyAccountItem";
 import { PartyAccountItemButton } from "@components/PartyAccountItemButton";
+import ArrowDropDownRoundedIcon from "@mui/icons-material/ArrowDropDownRounded";
+import ArrowDropUpRoundedIcon from "@mui/icons-material/ArrowDropUpRounded";
+import CloseIcon from "@mui/icons-material/Close";
+import SearchIcon from "@mui/icons-material/Search";
+import SentimentDissatisfied from "@mui/icons-material/SentimentDissatisfied";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
 export type PartySwitchItem = {
   id: string;
@@ -53,17 +53,14 @@ export type PartySwitchProps = {
 };
 
 const CustomDrawer = styled(Drawer)(() => ({
-  "& .MuiDrawer-paper": {
-    width: "30vw",
-  },
-  ["@media only screen and (max-width: 576px)"]: {
+  ["@media only screen and (max-width: 599px)"]: {
     "& .MuiDrawer-paper": {
-      width: "90vw",
+      width: "100vw",
     },
   },
-  ["@media only screen and (min-width: 577px) and (max-width: 992px)"]: {
+  ["@media only screen and (min-width: 600px)"]: {
     "& .MuiDrawer-paper": {
-      width: "40vw",
+      width: "417px",
     },
   },
 }));
@@ -80,6 +77,7 @@ export const PartySwitch = ({
   const [filter, setFilter] = useState("");
   const [offset, setOffset] = useState(50);
   const [containerRef, setContainerRef] = useState<HTMLDivElement | null>(null);
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   const mobileHideStyle = useMemo(
     () => ({ display: { xs: "none", md: "block" } }),
@@ -187,8 +185,16 @@ export const PartySwitch = ({
         tabIndex={0}
         PaperProps={{ ref: (ref: HTMLDivElement) => setContainerRef(ref) }}
       >
-        <Box sx={{ textAlign: "center", margin: "10px 0" }}>
+        <Box
+          m={3}
+          display="flex"
+          justifyContent="space-between"
+          alignItems="center"
+        >
           <Typography variant="overline">Accedi per un altro ente</Typography>
+          <IconButton onClick={() => toggleDrawer(false)}>
+            <CloseIcon aria-label="chiudi" width={3} height={3} />
+          </IconButton>
         </Box>
         <TextField
           label="Cerca ente"
@@ -198,7 +204,7 @@ export const PartySwitch = ({
                 <SearchIcon />
               </InputAdornment>
             ),
-            endAdornment: filter && (
+            endAdornment: filter && isMobile && (
               <InputAdornment
                 position="end"
                 onClick={() => setFilter("")}
@@ -212,7 +218,7 @@ export const PartySwitch = ({
           }}
           variant="outlined"
           size="small"
-          sx={{ margin: "10px 20px" }}
+          sx={{ mx: 3, mb: 1 }}
           onChange={handleFilterChange}
           value={filter}
         />
@@ -237,11 +243,10 @@ export const PartySwitch = ({
               sx={{
                 flexDirection: "row",
                 justifyContent: "center",
-                margin: "25px 0",
+                my: 2.5,
               }}
             >
               <SentimentDissatisfied
-                color="primary"
                 sx={{ verticalAlign: "middle", margin: "0 10px" }}
               />
               <Typography variant="body2" fontWeight={700} fontSize={18}>
@@ -249,7 +254,7 @@ export const PartySwitch = ({
               </Typography>
             </Box>
             <Button variant="contained" sx={{ margin: "0 20px" }}>
-              Aderisci per conto di un nuovo ente
+              Registra un nuovo ente
             </Button>
           </Fragment>
         )}

--- a/src/components/PartySwitch/PartySwitch.tsx
+++ b/src/components/PartySwitch/PartySwitch.tsx
@@ -193,7 +193,7 @@ export const PartySwitch = ({
         >
           <Typography variant="overline">Accedi per un altro ente</Typography>
           <IconButton onClick={() => toggleDrawer(false)}>
-            <CloseIcon aria-label="chiudi" width={3} height={3} />
+            <CloseIcon aria-label="chiudi" />
           </IconButton>
         </Box>
         <TextField

--- a/src/components/PartySwitch/PartySwitch.tsx
+++ b/src/components/PartySwitch/PartySwitch.tsx
@@ -58,9 +58,14 @@ const CustomDrawer = styled(Drawer)(() => ({
       width: "100vw",
     },
   },
-  ["@media only screen and (min-width: 600px)"]: {
+  ["@media only screen and (min-width: 600px) and (max-width: 1536px)"]: {
     "& .MuiDrawer-paper": {
-      width: "417px",
+      width: "420px",
+    },
+  },
+  ["@media only screen and (min-width: 1536px)"]: {
+    "& .MuiDrawer-paper": {
+      width: "35vw",
     },
   },
 }));


### PR DESCRIPTION
## Short description
Resposive design of the Drawer in the HeaderProduct Component.

### Preview
If it makes sense, please add one or more screenshots/videos.

## List of changes proposed in this pull request
- Change the stle of the drawer menu to follow new responsive mui italia design
- Add x icon button to allow closing of the drawer.
## Product
Area Riservata

## How to test
In the terminal run npm run storybook and go to HeaderProduct component. Check if in diferent viewports with chrome dev tools the Drawer follows the style in the figma below.
https://www.figma.com/design/pNBaYInnJjgyg1BZ1VeuJq/MUI-Italia---Design-System?node-id=14047-93971&t=wW5w040qnxzjO93b-4