### PR TITLE
[SELC-6649] feat: update IconButton styles default and primary

### DIFF
--- a/src/stories/IconButton.stories.tsx
+++ b/src/stories/IconButton.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { StoryObj, Meta } from "@storybook/react";
 
 import { IconButton } from "@mui/material";
 import DownloadRoundedIcon from "@mui/icons-material/DownloadRounded";
@@ -36,12 +36,11 @@ export default {
       },
     },
   },
-} as ComponentMeta<typeof IconButton>;
+} as Meta<typeof IconButton>;
 
-const Template: ComponentStory<typeof IconButton> = (args) => (
-  <IconButton aria-label="Scarica" {...args}>
-    <DownloadRoundedIcon />
-  </IconButton>
-);
-
-export const Default = Template.bind({});
+export const Default: StoryObj<typeof IconButton> = {
+  args: {
+    "aria-label": "Scarica",
+    children: <DownloadRoundedIcon />,
+  },
+};

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,5 +1,5 @@
-import { createTheme, Theme, alpha } from "@mui/material/styles";
 import { indigo } from "@mui/material/colors";
+import { alpha, createTheme, Theme } from "@mui/material/styles";
 
 /* Design Tokens */
 import { italia } from "@tokens";
@@ -589,6 +589,8 @@ export const theme: Theme = createTheme(foundation, {
       },
       styleOverrides: {
         root: {
+          color: foundation.palette.primary.main,
+          backgroundColor: foundation.palette.background.paper,
           "&:hover": {
             backgroundColor: alpha(foundation.palette.primary.main, 0.08),
           },
@@ -603,7 +605,12 @@ export const theme: Theme = createTheme(foundation, {
           },
         },
         colorPrimary: {
-          color: foundation.palette.primary.main,
+          color: foundation.palette.primary.contrastText,
+          backgroundColor: foundation.palette.primary.main,
+          "&:hover": {
+            backgroundColor: alpha(foundation.palette.primary.main, 0.08),
+            color: foundation.palette.primary.main,
+          },
         },
         minHeight: pxToRem(24),
         minWidth: pxToRem(24),


### PR DESCRIPTION
## Short description
Updated IconButton style to follow mui design figma https://www.figma.com/design/pNBaYInnJjgyg1BZ1VeuJq/MUI-Italia---Design-System?node-id=10130-48783&t=mTYs3IwgSsE4iZZz-4
### Preview
If it makes sense, please add one or more screenshots/videos.
primary:
![image](https://github.com/user-attachments/assets/fed40091-e19e-4753-a97d-b251e4bc92a3)
default:
![image](https://github.com/user-attachments/assets/013de7c1-1bcc-4c91-abd7-55fcfd8be001)

## List of changes proposed in this pull request
- updated style of default color variant
- updated style of icon button primary color variant
- removed deprecated ComponentStory, ComponentMeta imports

## Product
Area Riservata Enti
## How to test

yarn storybook