### PR TITLE
feat: [P4PU-945] allowing HeaderAccount component to be translated

### DIFF
--- a/src/components/HeaderAccount/HeaderAccount.stories.tsx
+++ b/src/components/HeaderAccount/HeaderAccount.stories.tsx
@@ -143,3 +143,41 @@ export const WithDocumentation: ComponentStory<typeof HeaderAccount> = () => (
     }}
   />
 );
+
+export const fullyLocalizedHeaderAccount: ComponentStory<
+  typeof HeaderAccount
+> = () => (
+  <HeaderAccount
+    enableDropdown
+    rootLink={pagoPALink}
+    loggedUser={user}
+    onAssistanceClick={() => {
+      console.log("Clicked/Tapped on Assistance");
+    }}
+    onDocumentationClick={() => {
+      console.log("Clicked/Tapped on Assistance");
+    }}
+    onLogin={() => {
+      console.log("User login");
+    }}
+    userActions={[
+      {
+        id: "profile",
+        label: "Profile",
+        onClick: () => {
+          console.log("Clicked/Tapped on Profile");
+        },
+        icon: <SettingsIcon fontSize="small" color="inherit" />,
+      },
+      {
+        id: "logout",
+        label: "Logout",
+        onClick: () => {
+          console.log("User logged out");
+        },
+        icon: <LogoutRoundedIcon fontSize="small" color="inherit" />,
+      },
+    ]}
+    translationsMap={{ assistance: "Help", documentation: "Documentation" }}
+  />
+);

--- a/src/components/HeaderAccount/HeaderAccount.tsx
+++ b/src/components/HeaderAccount/HeaderAccount.tsx
@@ -35,7 +35,7 @@ const defaultTranslationsMap = {
   logOut: "Esci",
   assistance: "Assistenza",
   documentation: "Manuale operativo",
-}
+};
 
 type HeaderAccountProps = {
   rootLink: RootLinkType;
@@ -49,10 +49,10 @@ type HeaderAccountProps = {
   enableAssistanceButton?: boolean;
   onDocumentationClick?: () => void;
   translationsMap?: {
-    logIn?: string,
-    logOut?: string,
-    assistance?: string,
-    documentation?: string,}
+    logIn?: string;
+    logOut?: string;
+    assistance?: string;
+    documentation?: string;};
 };
 
 export const HeaderAccount = ({

--- a/src/components/HeaderAccount/HeaderAccount.tsx
+++ b/src/components/HeaderAccount/HeaderAccount.tsx
@@ -30,6 +30,13 @@ export type RootLinkType = {
   title: string;
 };
 
+const defaultTranslationsMap = {
+  logIn: "Accedi",
+  logOut: "Esci",
+  assistance: "Assistenza",
+  documentation: "Manuale operativo",
+}
+
 type HeaderAccountProps = {
   rootLink: RootLinkType;
   loggedUser?: JwtUser | false;
@@ -41,6 +48,11 @@ type HeaderAccountProps = {
   enableLogin?: boolean;
   enableAssistanceButton?: boolean;
   onDocumentationClick?: () => void;
+  translationsMap?: {
+    logIn?: string,
+    logOut?: string,
+    assistance?: string,
+    documentation?: string,}
 };
 
 export const HeaderAccount = ({
@@ -54,6 +66,7 @@ export const HeaderAccount = ({
   enableDropdown = false,
   enableLogin = true,
   enableAssistanceButton = true,
+  translationsMap = defaultTranslationsMap,
 }: HeaderAccountProps) => (
   <Stack
     component="div"
@@ -103,7 +116,7 @@ export const HeaderAccount = ({
                 sx={{ display: ["none", "flex"] }}
                 weight="default"
               >
-                Manuale operativo
+                {translationsMap.documentation || defaultTranslationsMap.documentation}
               </ButtonNaked>
               <IconButton
                 size="small"
@@ -128,7 +141,7 @@ export const HeaderAccount = ({
                 sx={{ display: ["none", "flex"] }}
                 weight="default"
               >
-                Assistenza
+                {translationsMap.assistance || defaultTranslationsMap.assistance}
               </ButtonNaked>
               <IconButton
                 size="small"
@@ -152,7 +165,7 @@ export const HeaderAccount = ({
           {/* 2. Logged User with Logout CTA */}
           {enableLogin && loggedUser && !enableDropdown && (
             <Button variant="text" size="small" onClick={onLogout} title="Esci">
-              Esci
+              {translationsMap.logOut || defaultTranslationsMap.logOut}
             </Button>
           )}
 
@@ -164,7 +177,7 @@ export const HeaderAccount = ({
               onClick={onLogin}
               title="Accedi"
             >
-              Accedi
+              {translationsMap.logIn || defaultTranslationsMap.logIn}
             </Button>
           )}
         </Stack>


### PR DESCRIPTION
## Short description
This change allows to translate the HeaderAccount component passing custom strings to replace the fixed ones

### Preview
![image](https://github.com/user-attachments/assets/329ee18b-5eeb-43af-9a10-cfd7dc8dce61)

## List of changes proposed in this pull request
- Added an optional translation map object as prop to the HeaderAccount component
- Added a new storybook story to illustrate the new behaviour

## Product
Area Riservata Cittadino - Reference in issue [P4PU-945](https://pagopa.atlassian.net/browse/P4PU-945)

## How to test
story example has been added to the HeaderAccount stories, you can check it running the command
```bash
yarn storybook
```

[P4PU-945]: https://pagopa.atlassian.net/browse/P4PU-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ