### PR TITLE
feat(M20DS-87): header alert

### DIFF
--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -117,12 +117,7 @@ export const MIAlert: React.FC<MIAlertProps> = (props) => {
   const action = hasAction ? props.action : undefined;
 
   return (
-    <StyledAlert
-      severity={severity}
-      icon={getIcon(severity)}
-      layoutVariant={variant}
-      {...(variant === 'header' ? { description } : { description, title, action: undefined })}
-    >
+    <StyledAlert severity={severity} icon={getIcon(severity)} layoutVariant={variant}>
       <Stack direction={isMobile ? 'column' : 'row'} flex={1}>
         <Stack direction="column" flex={1} minWidth={0} gap={title ? '4px' : 0}>
           {title && <MUIAlertTitle color={getColor(theme, severity)}>{title}</MUIAlertTitle>}

--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -89,7 +89,10 @@ const StyledAlert = styled(MUIAlert, {
       padding: 0,
       overflow: 'inherit',
       lineHeight: layoutVariant === 'header' ? '20px' : '22px',
-      fontWeight: layoutVariant === 'header' ? 500 : theme.typography.fontWeightRegular,
+      fontWeight:
+        layoutVariant === 'header'
+          ? theme.typography.fontWeightMedium
+          : theme.typography.fontWeightRegular,
       fontSize: layoutVariant === 'header' ? '14px' : '16px',
       display: 'flex',
       flexDirection: 'column',

--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -39,8 +39,6 @@ interface DefaultAlertProps extends BaseAlertProps {
 // Header MIAlert variant
 interface HeaderAlertProps extends BaseAlertProps {
   variant: 'header';
-  title?: never;
-  action?: never;
 }
 
 export type MIAlertProps = DefaultAlertProps | HeaderAlertProps;
@@ -73,8 +71,7 @@ const StyledAlert = styled(MUIAlert, {
       borderRadius: 0,
       width: 'auto',
       boxSizing: 'border-box',
-      paddingTop: '10px !important',
-      paddingBottom: '10px !important',
+      padding: '10px 16px !important', // Override MUI's default padding with !important
     }),
 
     [theme.breakpoints.down('sm')]: {
@@ -91,8 +88,9 @@ const StyledAlert = styled(MUIAlert, {
     '& .MuiAlert-message': {
       padding: 0,
       overflow: 'inherit',
-      lineHeight: '22px',
-      fontWeight: theme.typography.fontWeightRegular,
+      lineHeight: layoutVariant === 'header' ? '20px' : '22px',
+      fontWeight: layoutVariant === 'header' ? 500 : theme.typography.fontWeightRegular,
+      fontSize: layoutVariant === 'header' ? '14px' : '16px',
       display: 'flex',
       flexDirection: 'column',
       overflowWrap: 'anywhere',
@@ -104,19 +102,24 @@ const StyledAlert = styled(MUIAlert, {
   };
 });
 
-export const MIAlert = ({
-  severity = 'success',
-  variant = 'default',
-  title,
-  description,
-  action,
-  ...rest
-}: MIAlertProps) => {
+export const MIAlert: React.FC<MIAlertProps> = (props) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
+  const { severity, description, variant = 'default' } = props;
+  const hasTitle = 'title' in props && !!props.title;
+  const hasAction = 'action' in props && !!props.action;
+
+  const title = hasTitle ? props.title : undefined;
+  const action = hasAction ? props.action : undefined;
+
   return (
-    <StyledAlert severity={severity} icon={getIcon(severity)} layoutVariant={variant} {...rest}>
+    <StyledAlert
+      severity={severity}
+      icon={getIcon(severity)}
+      layoutVariant={variant}
+      {...(variant === 'header' ? { description } : { description, title, action: undefined })}
+    >
       <Stack direction={isMobile ? 'column' : 'row'} flex={1}>
         <Stack direction="column" flex={1} minWidth={0} gap={title ? '4px' : 0}>
           {title && <MUIAlertTitle color={getColor(theme, severity)}>{title}</MUIAlertTitle>}

--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -3,7 +3,6 @@
 import { ButtonNaked } from '@components/ButtonNaked';
 import { AlertTitle as MUIAlertTitle, Stack, styled, useMediaQuery, useTheme } from '@mui/material';
 import MUIAlert, { AlertProps as MUIAlertProps } from '@mui/material/Alert';
-import type { Theme } from '@mui/material/styles';
 import { ElementType, HTMLAttributeAnchorTarget } from 'react';
 import { getColor, getIcon } from './utils';
 
@@ -18,13 +17,6 @@ type LinkCTA = {
 type AlertCTA = ButtonCTA | LinkCTA;
 
 export type AllowedAlertSeverity = 'success' | 'info' | 'warning' | 'error';
-
-interface MIAlertProps extends Pick<MUIAlertProps, 'severity'> {
-  title?: string;
-  description: string;
-  action?: AlertCTA;
-}
-
 interface MIAlertCtaProps {
   cta: AlertCTA;
   ariaLabelledBy?: string;
@@ -32,48 +24,89 @@ interface MIAlertCtaProps {
   isMobile: boolean;
 }
 
-const StyledAlert = styled(MUIAlert)(
-  ({ theme, severity = 'success' }: { theme: Theme; severity?: AllowedAlertSeverity }) => {
-    const severityPalette = theme.palette[severity];
+// Props shared by all variants
+interface BaseAlertProps extends Pick<MUIAlertProps, 'severity'> {
+  description: string;
+}
 
-    return {
+// Default MIAlert variant (allows title and action)
+interface DefaultAlertProps extends BaseAlertProps {
+  variant?: 'default';
+  title?: string;
+  action?: AlertCTA;
+}
+
+// Header MIAlert variant
+interface HeaderAlertProps extends BaseAlertProps {
+  variant: 'header';
+  title?: never;
+  action?: never;
+}
+
+export type MIAlertProps = DefaultAlertProps | HeaderAlertProps;
+
+interface StyledAlertProps extends MUIAlertProps {
+  layoutVariant?: 'default' | 'header';
+}
+
+const StyledAlert = styled(MUIAlert, {
+  // This prevents 'layoutVariant' from being written to the HTML DOM
+  shouldForwardProp: (prop) => prop !== 'layoutVariant',
+})<StyledAlertProps>(({ theme, severity = 'success', layoutVariant }) => {
+  const severityPalette = theme.palette[severity];
+
+  return {
+    backgroundColor: severityPalette[100],
+    justifyContent: layoutVariant === 'header' ? 'center' : 'flex-start',
+    alignItems: layoutVariant === 'header' ? 'center' : 'flex-start',
+
+    ...(layoutVariant === 'default' && {
       border: '1px solid',
       borderRadius: 8,
       padding: theme.spacing(2),
-      alignItems: 'flex-start',
       borderColor: severityPalette.main,
-      backgroundColor: severityPalette[100],
+    }),
 
-      [theme.breakpoints.down('sm')]: {
-        alignItems: 'flex-start',
-      },
+    // different styles for the 'header' variant
+    ...(layoutVariant === 'header' && {
+      border: 'none',
+      borderRadius: 0,
+      width: 'auto',
+      boxSizing: 'border-box',
+      paddingTop: '10px !important',
+      paddingBottom: '10px !important',
+    }),
 
-      '& .MuiAlert-icon': {
-        opacity: 1,
-        alignItems: 'center',
-        marginRight: theme.spacing(1),
-        color: severityPalette[850],
-      },
+    [theme.breakpoints.down('sm')]: {
+      alignItems: layoutVariant === 'header' ? 'center' : 'flex-start',
+    },
 
-      '& .MuiAlert-message': {
-        padding: 0,
-        overflow: 'inherit',
-        lineHeight: '22px',
-        fontWeight: theme.typography.fontWeightRegular,
-        flex: 1,
-        width: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        overflowWrap: 'anywhere',
-        wordBreak: 'break-word',
-        color: severityPalette[850],
-      },
-    };
-  }
-);
+    '& .MuiAlert-icon': {
+      opacity: 1,
+      alignItems: 'center',
+      marginRight: theme.spacing(1),
+      color: severityPalette[850],
+    },
+
+    '& .MuiAlert-message': {
+      padding: 0,
+      overflow: 'inherit',
+      lineHeight: '22px',
+      fontWeight: theme.typography.fontWeightRegular,
+      display: 'flex',
+      flexDirection: 'column',
+      overflowWrap: 'anywhere',
+      wordBreak: 'break-word',
+      color: severityPalette[850],
+      flex: layoutVariant === 'header' ? '0 1 auto' : 1,
+      width: layoutVariant === 'header' ? 'auto' : '100%',
+    },
+  };
+});
 
 export const MIAlert = ({
   severity = 'success',
+  variant = 'default',
   title,
   description,
   action,
@@ -83,7 +116,7 @@ export const MIAlert = ({
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   return (
-    <StyledAlert severity={severity} icon={getIcon(severity)} {...rest}>
+    <StyledAlert severity={severity} icon={getIcon(severity)} layoutVariant={variant} {...rest}>
       <Stack direction={isMobile ? 'column' : 'row'} flex={1}>
         <Stack direction="column" flex={1} minWidth={0} gap={title ? '4px' : 0}>
           {title && <MUIAlertTitle color={getColor(theme, severity)}>{title}</MUIAlertTitle>}

--- a/src/stories/MIAlert.stories.tsx
+++ b/src/stories/MIAlert.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { breakpointsChromaticValues } from '@theme';
-import { MIAlert } from '@components/MIAlert';
+import { MIAlert, MIAlertProps } from '@components/MIAlert';
 import { Box } from '@mui/material';
+import { JSX } from 'react/jsx-runtime';
 
 const componentMaxWidth = 900;
 
@@ -94,6 +95,33 @@ export const NoTitleWithCTA: Story = {
   },
 };
 
+export const HeaderVariant: Story = {
+  args: {
+    variant: 'header',
+    severity: 'success',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit auctor dui, at convallis nisl.',
+  },
+  render: (args: JSX.IntrinsicAttributes & MIAlertProps) => (
+    <div
+      style={{
+        padding: 0,
+        backgroundColor: '#f5f5f5',
+        border: '2px dashed #ccc',
+        minHeight: '200px',
+      }}
+    >
+      <p style={{ marginTop: 0, fontFamily: 'sans-serif', color: '#666' }}>
+        Parent Container - simula un header di pagina con larghezza limitata e sfondo diverso.
+        L'Alert dovrebbe adattarsi a questo contesto, occupando tutta la larghezza disponibile senza
+        causare overflow o problemi di layout.
+      </p>
+
+      <MIAlert {...args} />
+    </div>
+  ),
+};
+
 /* ------------------------------ Stress-test stories ------------------------------ */
 
 export const StressUnbroken: Story = {
@@ -117,4 +145,29 @@ export const StressUnbrokenNoTitle: Story = {
       target: '_self',
     },
   },
+};
+
+export const StressUnbrokenHeaderVariant: Story = {
+  args: {
+    variant: 'header',
+    description: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
+  },
+  render: (args: JSX.IntrinsicAttributes & MIAlertProps) => (
+    <div
+      style={{
+        padding: 0,
+        backgroundColor: '#f5f5f5',
+        border: '2px dashed #ccc',
+        minHeight: '200px',
+      }}
+    >
+      <p style={{ marginTop: 0, fontFamily: 'sans-serif', color: '#666' }}>
+        Parent Container - simula un header di pagina con larghezza limitata e sfondo diverso.
+        L'Alert dovrebbe adattarsi a questo contesto, occupando tutta la larghezza disponibile senza
+        causare overflow o problemi di layout.
+      </p>
+
+      <MIAlert {...args} />
+    </div>
+  ),
 };

--- a/src/stories/MIAlert.stories.tsx
+++ b/src/stories/MIAlert.stories.tsx
@@ -1,8 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { breakpointsChromaticValues } from '@theme';
-import { MIAlert, MIAlertProps } from '@components/MIAlert';
+import { MIAlert } from '@components/MIAlert';
 import { Box } from '@mui/material';
-import { JSX } from 'react/jsx-runtime';
 
 const componentMaxWidth = 900;
 
@@ -45,6 +44,25 @@ const meta: Meta<React.ComponentProps<typeof MIAlert>> = {
 export default meta;
 
 type Story = StoryObj<React.ComponentProps<typeof MIAlert>>;
+
+const withHeaderContext = (Story: React.ElementType) => (
+  <div
+    style={{
+      padding: 0,
+      backgroundColor: '#f5f5f5',
+      border: '2px dashed #ccc',
+      minHeight: '200px',
+    }}
+  >
+    <p style={{ marginTop: 0, fontFamily: 'sans-serif', color: '#666' }}>
+      Parent Container - simula un header di pagina con larghezza limitata e sfondo diverso. L'Alert
+      dovrebbe adattarsi a questo contesto, occupando tutta la larghezza disponibile senza causare
+      overflow o problemi di layout.
+    </p>
+
+    <Story />
+  </div>
+);
 
 /* ------------------------------ Normal stories ------------------------------ */
 
@@ -102,24 +120,7 @@ export const HeaderVariant: Story = {
     description:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit auctor dui, at convallis nisl.',
   },
-  render: (args: JSX.IntrinsicAttributes & MIAlertProps) => (
-    <div
-      style={{
-        padding: 0,
-        backgroundColor: '#f5f5f5',
-        border: '2px dashed #ccc',
-        minHeight: '200px',
-      }}
-    >
-      <p style={{ marginTop: 0, fontFamily: 'sans-serif', color: '#666' }}>
-        Parent Container - simula un header di pagina con larghezza limitata e sfondo diverso.
-        L'Alert dovrebbe adattarsi a questo contesto, occupando tutta la larghezza disponibile senza
-        causare overflow o problemi di layout.
-      </p>
-
-      <MIAlert {...args} />
-    </div>
-  ),
+  decorators: [withHeaderContext],
 };
 
 /* ------------------------------ Stress-test stories ------------------------------ */
@@ -152,22 +153,5 @@ export const StressUnbrokenHeaderVariant: Story = {
     variant: 'header',
     description: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
   },
-  render: (args: JSX.IntrinsicAttributes & MIAlertProps) => (
-    <div
-      style={{
-        padding: 0,
-        backgroundColor: '#f5f5f5',
-        border: '2px dashed #ccc',
-        minHeight: '200px',
-      }}
-    >
-      <p style={{ marginTop: 0, fontFamily: 'sans-serif', color: '#666' }}>
-        Parent Container - simula un header di pagina con larghezza limitata e sfondo diverso.
-        L'Alert dovrebbe adattarsi a questo contesto, occupando tutta la larghezza disponibile senza
-        causare overflow o problemi di layout.
-      </p>
-
-      <MIAlert {...args} />
-    </div>
-  ),
+  decorators: [withHeaderContext],
 };


### PR DESCRIPTION
## Short description
This pull request introduces a new "header" variant to the `MIAlert` component, allowing it to be styled and used specifically for page header contexts. The changes include updates to the component's props, styling logic, and Storybook stories to demonstrate and test the new variant.

**Component API and Prop Changes:**

- Refactored the `MIAlertProps` type to support a discriminated union, introducing a `variant` prop with `'default'` and `'header'` options. The `'header'` variant disallows `title` and `action` props.
- Updated the main `MIAlert` function signature to accept the new `variant` prop and pass it as `layoutVariant` to the styled component.

**Styling and Layout:**

- Enhanced the `StyledAlert` component to conditionally apply different styles based on the `layoutVariant` prop, ensuring the "header" variant has no border, zero border-radius, and fits naturally in header containers. 

**Storybook and Testing:**

- Added new stories (`HeaderVariant`, `StressUnbrokenHeaderVariant`) to Storybook to showcase and test the new "header" variant, including stress tests for long unbroken text.

### Preview
<img width="1085" height="424" alt="Screenshot 2026-04-29 alle 10 51 31" src="https://github.com/user-attachments/assets/8428e5c8-07d4-4487-bf27-b8721d68a59e" />


