### PR TITLE
feat(M20DS-30): add sx support to MIAlert

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/mui-italia",
-  "version": "2.3.1",
+  "version": "2.3.1-beta.1",
   "author": {
     "name": "PagoPA"
   },

--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -2,6 +2,7 @@
 
 import { ButtonNaked } from '@components/ButtonNaked';
 import { AlertTitle as MUIAlertTitle, Stack, styled, useMediaQuery, useTheme } from '@mui/material';
+import { ResponsiveStyleValue } from '@mui/system';
 import MUIAlert, { AlertProps as MUIAlertProps } from '@mui/material/Alert';
 import { ElementType, HTMLAttributeAnchorTarget } from 'react';
 import { getColor, getIcon } from './utils';
@@ -24,9 +25,21 @@ interface MIAlertCtaProps {
   isMobile: boolean;
 }
 
+type MarginValue = ResponsiveStyleValue<number | string>;
+
+type AlertMargin = {
+  mt?: MarginValue;
+  mb?: MarginValue;
+  ml?: MarginValue;
+  mr?: MarginValue;
+  mx?: MarginValue;
+  my?: MarginValue;
+};
+
 // Props shared by all variants
-interface BaseAlertProps extends Pick<MUIAlertProps, 'severity' | 'sx'> {
+interface BaseAlertProps extends Pick<MUIAlertProps, 'severity'> {
   description: string;
+  margin?: AlertMargin;
 }
 
 // Default MIAlert variant (allows title and action)
@@ -109,7 +122,7 @@ export const MIAlert: React.FC<MIAlertProps> = (props) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const { severity, description, variant = 'default', sx } = props;
+  const { severity, description, variant = 'default', margin } = props;
   const hasTitle = 'title' in props && !!props.title;
   const hasAction = 'action' in props && !!props.action;
 
@@ -117,7 +130,7 @@ export const MIAlert: React.FC<MIAlertProps> = (props) => {
   const action = hasAction ? props.action : undefined;
 
   return (
-    <StyledAlert severity={severity} icon={getIcon(severity)} layoutVariant={variant} sx={sx}>
+    <StyledAlert severity={severity} icon={getIcon(severity)} layoutVariant={variant} sx={margin}>
       <Stack direction={isMobile ? 'column' : 'row'} flex={1}>
         <Stack direction="column" flex={1} minWidth={0} gap={title ? '4px' : 0}>
           {title && <MUIAlertTitle color={getColor(theme, severity)}>{title}</MUIAlertTitle>}

--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -25,7 +25,7 @@ interface MIAlertCtaProps {
 }
 
 // Props shared by all variants
-interface BaseAlertProps extends Pick<MUIAlertProps, 'severity'> {
+interface BaseAlertProps extends Pick<MUIAlertProps, 'severity' | 'sx'> {
   description: string;
 }
 
@@ -109,7 +109,7 @@ export const MIAlert: React.FC<MIAlertProps> = (props) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const { severity, description, variant = 'default' } = props;
+  const { severity, description, variant = 'default', sx } = props;
   const hasTitle = 'title' in props && !!props.title;
   const hasAction = 'action' in props && !!props.action;
 
@@ -117,7 +117,7 @@ export const MIAlert: React.FC<MIAlertProps> = (props) => {
   const action = hasAction ? props.action : undefined;
 
   return (
-    <StyledAlert severity={severity} icon={getIcon(severity)} layoutVariant={variant}>
+    <StyledAlert severity={severity} icon={getIcon(severity)} layoutVariant={variant} sx={sx}>
       <Stack direction={isMobile ? 'column' : 'row'} flex={1}>
         <Stack direction="column" flex={1} minWidth={0} gap={title ? '4px' : 0}>
           {title && <MUIAlertTitle color={getColor(theme, severity)}>{title}</MUIAlertTitle>}

--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -2,7 +2,7 @@
 
 import { ButtonNaked } from '@components/ButtonNaked';
 import { AlertTitle as MUIAlertTitle, Stack, styled, useMediaQuery, useTheme } from '@mui/material';
-import { ResponsiveStyleValue } from '@mui/system';
+import type { SystemProps, Theme } from '@mui/system';
 import MUIAlert, { AlertProps as MUIAlertProps } from '@mui/material/Alert';
 import { ElementType, HTMLAttributeAnchorTarget } from 'react';
 import { getColor, getIcon } from './utils';
@@ -26,21 +26,26 @@ interface MIAlertCtaProps {
   isMobile: boolean;
 }
 
-type MarginValue = ResponsiveStyleValue<number | string>;
+type MarginKeys =
+  | 'm'
+  | 'mt'
+  | 'mr'
+  | 'mb'
+  | 'ml'
+  | 'mx'
+  | 'my'
+  | 'margin'
+  | 'marginTop'
+  | 'marginRight'
+  | 'marginBottom'
+  | 'marginLeft';
 
-type AlertMargin = {
-  mt?: MarginValue;
-  mb?: MarginValue;
-  ml?: MarginValue;
-  mr?: MarginValue;
-  mx?: MarginValue;
-  my?: MarginValue;
-};
+type MarginSxProps = Pick<SystemProps<Theme>, MarginKeys>;
 
 // Props shared by all variants
 interface BaseAlertProps extends Pick<MUIAlertProps, 'severity'> {
   description: string;
-  margin?: AlertMargin;
+  sx?: MarginSxProps;
 }
 
 // Default MIAlert variant (allows title and action)
@@ -129,13 +134,14 @@ export const MIAlert: React.FC<MIAlertProps> = ({
   variant = 'default',
   title,
   action,
+  sx,
   ...rest
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   return (
-    <StyledAlert severity={severity} icon={getIcon(severity)} variant={variant} {...rest}>
+    <StyledAlert severity={severity} icon={getIcon(severity)} variant={variant} sx={sx} {...rest}>
       <Stack direction={isMobile ? 'column' : 'row'} flex={1}>
         <Stack direction="column" flex={1} minWidth={0} gap={title ? '4px' : 0}>
           {title && <MUIAlertTitle color={getColor(theme, severity)}>{title}</MUIAlertTitle>}


### PR DESCRIPTION
## Short description
Add on components MIAlert an addition sx support for margin

### Preview
If it makes sense, please add one or more screenshots/videos.

## List of changes proposed in this pull request
- added typed margin-only sx support to MIAlert

## Product
Design System (MUI Italia)

## How to test

1. Run the frontend applications (pn-pa, pn-pf, pn-pg)
2. Verify that all alerts are correctly rendered
3. Check that spacing (sx, e.g. mt, mb) is applied as expected
4. Verify that unsupported sx properties (e.g. color) do not compile and are correctly restricted by typings
5. Validate no regressions in alert behavior or layout