### PR TITLE
fix(SENDDPF-24): improve banner semantic grouping

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -118,7 +118,7 @@ export const Banner = (props: BannerProps) => {
   });
 
   return (
-    <Root colorStyle={model.colorStyle} {...rest}>
+    <Root {...rest} component="section" colorStyle={model.colorStyle} aria-labelledby={titleId}>
       <Inner>{content}</Inner>
     </Root>
   );


### PR DESCRIPTION
## Short description
Improved Banner accessibility semantics by using a semantic section container associated with the banner title through aria-labelledby.

This allows assistive technologies to recognize the banner as a named region instead of a generic container.

### Preview
none

## List of changes proposed in this pull request
- Changed Banner root element from generic div to semantic section
- Added aria-labelledby linking the banner container to its title
- Improved semantic grouping for screen readers and assistive technologies
- Preserved existing Banner API and visual behavior

## Product
SEND / Piattaforma Notifiche

## How to test
1. Build and link the updated mui-italia package.

2. Verify Banner usage in pn-personafisica-webapp:
   - Notifications list page
   - Notification detail page
   - User profile / digital domicile section

3. Verify Banner usage in pn-personagiuridica-webapp (where applicable).

4. For each Banner instance:
   - verify that the root element is rendered as a <section>
   - verify that aria-labelledby references the banner title id
   - verify that no visual regressions are introduced

5. Enable VoiceOver and navigate to the banner.

6. Verify that the banner is announced as a named region using the banner title as its accessible label.