### PR TITLE
fix(M20DS-89): reset state on MISpidSelectOIDialog close and fix SPID names

### DIFF
--- a/src/components/MISpidSelectOIDialog/MISpidSelectOIDialog.tsx
+++ b/src/components/MISpidSelectOIDialog/MISpidSelectOIDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import ClearOutlinedIcon from '@mui/icons-material/ClearOutlined';
 import {
@@ -112,8 +112,12 @@ export const MISpidSelectOIDialog: React.FC<Props> = ({
     onClose();
   };
 
-  // Unmounts the component when is closed, so that the internal state is reset on next open
-  if (!show) return null;
+  useEffect(() => {
+    if (!show) {
+      setAuthorizingEntityId(null);
+      setUnavailableIdp(null);
+    }
+  }, [show]);
 
   return (
     <Dialog

--- a/src/components/MISpidSelectOIDialog/MISpidSelectOIDialog.tsx
+++ b/src/components/MISpidSelectOIDialog/MISpidSelectOIDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import ClearOutlinedIcon from '@mui/icons-material/ClearOutlined';
 import {
@@ -13,9 +13,9 @@ import {
 
 import { MIAlert } from '@components/MIAlert';
 import { IDP } from 'types/spid';
+import ErrorState from './ErrorState';
 import SpidList from './SpidList';
 import { getSpidDisplayName } from './utils';
-import ErrorState from './ErrorState';
 
 const defaultTranslationsMap = {
   title: 'Accedi con SPID',
@@ -89,6 +89,7 @@ export const MISpidSelectOIDialog: React.FC<Props> = ({
 
   const [authorizingEntityId, setAuthorizingEntityId] = useState<string | null>(null);
   const [unavailableIdp, setUnavailableIdp] = useState<string | null>(null);
+  const dialogContentRef = useRef<HTMLDivElement>(null);
 
   const t = { ...defaultTranslationsMap, ...translationsMap };
 
@@ -97,6 +98,7 @@ export const MISpidSelectOIDialog: React.FC<Props> = ({
   const onSpidSelect = (idp: IDP) => {
     if (!idp.active || idp.status !== 'OK') {
       setUnavailableIdp(getSpidDisplayName(idp));
+      dialogContentRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
       onUnavailableIdpClick?.(idp);
       return;
     }
@@ -110,11 +112,8 @@ export const MISpidSelectOIDialog: React.FC<Props> = ({
     onClose();
   };
 
-  useEffect(() => {
-    if (!show) {
-      setUnavailableIdp(null);
-    }
-  }, [show]);
+  // Unmounts the component when is closed, so that the internal state is reset on next open
+  if (!show) return null;
 
   return (
     <Dialog
@@ -124,7 +123,11 @@ export const MISpidSelectOIDialog: React.FC<Props> = ({
       transitionDuration={0}
       onClose={handleCloseDialog}
     >
-      <DialogContent id="spidSelect" sx={{ p: 3, width: { xs: '100%', sm: '410px', lg: '600px' } }}>
+      <DialogContent
+        id="spidSelect"
+        ref={dialogContentRef}
+        sx={{ p: 3, width: { xs: '100%', sm: '410px', lg: '600px' } }}
+      >
         <Stack
           direction="row"
           display="flex"

--- a/src/components/MISpidSelectOIDialog/SpidList.tsx
+++ b/src/components/MISpidSelectOIDialog/SpidList.tsx
@@ -77,7 +77,13 @@ const SpidList: React.FC<Props> = ({
               aria-label={displayName}
             >
               <Box display="flex" justifyContent="space-between" alignItems="center" width="100%">
-                <Typography fontSize="14px" fontWeight="500" noWrap sx={{ color: '#555C70' }}>
+                <Typography
+                  fontSize="14px"
+                  fontWeight="500"
+                  textTransform="uppercase"
+                  noWrap
+                  sx={{ color: '#555C70' }}
+                >
                   {displayName}
                 </Typography>
 

--- a/src/components/MISpidSelectOIDialog/__mocks__/IDPS.mock.ts
+++ b/src/components/MISpidSelectOIDialog/__mocks__/IDPS.mock.ts
@@ -1,18 +1,16 @@
 import { IDP } from 'types/spid';
 
-export const MOCK_IDP_UNAVAILABLE: Array<IDP> = [
-  {
-    entityID: 'https://broken.idp.it',
-    pointer: 'https://broken.idp.it/sso',
-    status: 'WARNING',
-    idpSSOEndpoints: {
-      redirect: 'https://broken.idp.it/sso/redirect',
-    },
-    certificates: [],
-    friendlyName: 'Broken IDP',
-    active: true,
+export const MOCK_IDP_UNAVAILABLE: IDP = {
+  entityID: 'https://broken.idp.it',
+  pointer: 'https://broken.idp.it/sso',
+  status: 'WARNING',
+  idpSSOEndpoints: {
+    redirect: 'https://broken.idp.it/sso/redirect',
   },
-];
+  certificates: [],
+  friendlyName: 'Broken IDP',
+  active: true,
+};
 
 export const IDPS_MOCK: Array<IDP> = [
   {

--- a/src/components/MISpidSelectOIDialog/utils.ts
+++ b/src/components/MISpidSelectOIDialog/utils.ts
@@ -1,21 +1,20 @@
 import { IDP } from 'types/spid';
 
 export const SPID_DISPLAY_NAME = {
-  'https://posteid.poste.it': 'POSTE ID',
-  'https://identity.infocert.it': 'INFOCERT ID',
-  'https://loginspid.aruba.it': 'ARUBA ID',
-  'https://id.lepida.it/idp/shibboleth': 'LEPIDA ID',
-  'https://identity.sieltecloud.it': 'SIELTE ID',
-  'https://idp.namirialtsp.com/idp': 'NAMIRIAL ID',
-  'https://login.id.tim.it/affwebservices/public/saml2sso': 'TIM ID',
-  'https://spid.register.it': 'SPIDITALIA',
-  'https://id.eht.eu': 'ETNA ID',
-  'https://loginspid.infocamere.it': 'ID INFOCAMERE',
-  'https://idp.intesigroup.com': 'INTESI GROUP SPID',
-  'https://spid.teamsystem.com/idp': 'TEAMSYSTEM ID',
+  'https://posteid.poste.it': 'Poste ID',
+  'https://identity.infocert.it': 'InfoCert ID',
+  'https://loginspid.aruba.it': 'Aruba ID',
+  'https://id.lepida.it/idp/shibboleth': 'Lepida ID',
+  'https://identity.sieltecloud.it': 'Sielte ID',
+  'https://idp.namirialtsp.com/idp': 'Namirial ID',
+  'https://login.id.tim.it/affwebservices/public/saml2sso': 'TIM id',
+  'https://spid.register.it': 'SpidItalia',
+  'https://id.eht.eu': 'Etna ID',
+  'https://loginspid.infocamere.it': 'ID InfoCamere',
+  'https://idp.intesigroup.com': 'Intesi Group SPID',
+  'https://spid.teamsystem.com/idp': 'TeamSystem ID',
   'https://idp.uat.oneid.pagopa.it': 'INTERNAL IDP',
 };
 
 export const getSpidDisplayName = (idp: IDP): string =>
-  SPID_DISPLAY_NAME[idp.entityID as keyof typeof SPID_DISPLAY_NAME] ??
-  idp.friendlyName.toUpperCase();
+  SPID_DISPLAY_NAME[idp.entityID as keyof typeof SPID_DISPLAY_NAME] ?? idp.friendlyName;

--- a/src/stories/MISpidSelectOIDialog.stories.tsx
+++ b/src/stories/MISpidSelectOIDialog.stories.tsx
@@ -82,7 +82,7 @@ export const Loading: Story = {
 export const UnavailableIdp: Story = {
   args: {
     ...Default.args,
-    idps: MOCK_IDP_UNAVAILABLE,
+    idps: [...IDPS_MOCK, MOCK_IDP_UNAVAILABLE],
   },
   parameters: {
     docs: {


### PR DESCRIPTION
## Short description
Reset state on MISpidSelectOIDialog close, make SPID names equal to commercial names and implement scroll to top when an IDP is unavailable in order to show the Alert correctly.

## List of changes proposed in this pull request
- Reset state on MISpidSelectOIDialog close
- Make SPID names equal to commercial names
- Implement scroll to top when an IDP is unavailable in order to show the Alert correctly.

## How to test
Test with Verdaccio