### PR TITLE
fix(M20DS-45): required attribute conditionally based on selected value

### DIFF
--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -89,6 +89,10 @@ const Autocomplete = <T, M extends boolean | undefined = false>({
     getOptionLabel,
   });
 
+  const hasSelectedValue = Array.isArray(currentValue)
+    ? currentValue.length > 0
+    : currentValue != null;
+
   const setInputValue = (v: string, reason: InputChangeReason) => {
     // non controlled input
     if (inputValue === undefined) {
@@ -371,6 +375,7 @@ const Autocomplete = <T, M extends boolean | undefined = false>({
           error={error}
           helperText={helperText}
           inputProps={{
+            required: required && !hasSelectedValue,
             role: 'combobox',
             'aria-expanded': isOpen,
             'aria-controls': listboxId,


### PR DESCRIPTION
## Short description

Fix the required validation on the Autocomplete component: the required error is no longer shown when at least one item is selected.

## List of changes proposed in this pull request

- Fix the `required` prop logic in `Autocomplete`

## How to test

- With Verdacio
- Navigate to the "Nuova Delega" page, select "Solo enti selezionati" and pick at least one item
- Submit the form and verify that no required error is shown
- Clear the field and submit again, then verify that the required error is correctly displayed