### PR TITLE
fix(M20DS-30): update MIAlert component to accept ReactNode for description

### DIFF
--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -28,7 +28,7 @@ interface MIAlertCtaProps {
 
 // Props shared by all variants
 interface BaseAlertProps extends Pick<MUIAlertProps, 'severity' | 'id'> {
-  description: ReactNode;
+  children: ReactNode;
   sx?: MarginSxProps;
 }
 
@@ -114,7 +114,7 @@ const StyledAlert = styled(MUIAlert as React.ComponentType<MUIBaseAlertProps>, {
 
 export const MIAlert: React.FC<MIAlertProps> = ({
   severity,
-  description,
+  children,
   variant = 'default',
   title,
   action,
@@ -129,7 +129,7 @@ export const MIAlert: React.FC<MIAlertProps> = ({
       <Stack direction={isMobile ? 'column' : 'row'} flex={1}>
         <Stack direction="column" flex={1} minWidth={0} gap={title ? '4px' : 0}>
           {title && <MUIAlertTitle color={getColor(theme, severity)}>{title}</MUIAlertTitle>}
-          {description}
+          {children}
         </Stack>
         {action && <MIAlertCta cta={action} severity={severity} isMobile={isMobile} />}
       </Stack>

--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -3,7 +3,7 @@
 import { ButtonNaked } from '@components/ButtonNaked';
 import { AlertTitle as MUIAlertTitle, Stack, styled, useMediaQuery, useTheme } from '@mui/material';
 import MUIAlert, { AlertProps as MUIAlertProps } from '@mui/material/Alert';
-import { ElementType, HTMLAttributeAnchorTarget } from 'react';
+import { ElementType, HTMLAttributeAnchorTarget, ReactNode } from 'react';
 import { getColor, getIcon } from './utils';
 import { MarginSxProps } from '@types';
 
@@ -28,7 +28,7 @@ interface MIAlertCtaProps {
 
 // Props shared by all variants
 interface BaseAlertProps extends Pick<MUIAlertProps, 'severity' | 'id'> {
-  description: string;
+  description: ReactNode;
   sx?: MarginSxProps;
 }
 

--- a/src/docs/MIAlert.mdx
+++ b/src/docs/MIAlert.mdx
@@ -65,29 +65,25 @@ Nella variante `default` è possibile aggiungere una CTA opzionale tramite la pr
 
 <Canvas of={MIAlertStories.DefaultCTAClick} />
 
-## Descrizione personalizzata
+## Contenuto personalizzato
 
-La prop `description` accetta sia una semplice stringa sia un `ReactNode` custom.
-Questo permette di passare contenuti più ricchi come testo formattato, link o
-liste, mantenendo lo stile dell'alert.
+Il contenuto principale dell'alert si passa tramite i `children`, che accettano sia
+una semplice stringa sia un `ReactNode` custom. Questo permette di passare contenuti
+più ricchi come testo formattato, link o liste, mantenendo lo stile dell'alert.
 
 ```tsx
-<MIAlert
-  severity="error"
-  title="Titolo dell'Alert"
-  description={
-    <span>
-      Controlla i seguenti elementi:
-      <ul>
-        <li>Verifica i dati anagrafici inseriti</li>
-        <li>Controlla l'indirizzo email</li>
-        <li>
-          Consulta la <a href="https://test.com">guida online</a> per maggiori dettagli
-        </li>
-      </ul>
-    </span>
-  }
-/>
+<MIAlert severity="error" title="Titolo dell'Alert">
+  <span>
+    Controlla i seguenti elementi:
+    <ul>
+      <li>Verifica i dati anagrafici inseriti</li>
+      <li>Controlla l'indirizzo email</li>
+      <li>
+        Consulta la <a href="https://test.com">guida online</a> per maggiori dettagli
+      </li>
+    </ul>
+  </span>
+</MIAlert>
 ```
 
 <Canvas of={MIAlertStories.CustomNodeDescription} />
@@ -108,7 +104,7 @@ queste indicazioni:
 - **CTA descrittive.** Se usi una `action`, l'etichetta deve descrivere chiaramente
   l'esito dell'interazione (evita testi generici come "Clicca qui").
 
-- **Contenuti custom.** Quando passi un `ReactNode` come `description`, usa una
+- **Contenuti custom.** Quando passi un `ReactNode` come `children`, usa una
   struttura semantica corretta (es. `<ul>`/`<li>` per le liste, `<a>` per i link)
   così da preservare la navigabilità con tecnologie assistive.
 

--- a/src/docs/MIAlert.mdx
+++ b/src/docs/MIAlert.mdx
@@ -1,0 +1,116 @@
+import { Meta, Title, Controls, Canvas } from '@storybook/addon-docs/blocks';
+import * as MIAlertStories from '../stories/MIAlert.stories.tsx';
+
+<Meta of={MIAlertStories} />
+
+<Title />
+
+Il componente **MIAlert** comunica all'utente un messaggio di stato o una
+segnalazione contestuale (esito di un'operazione, avviso, errore o informazione).
+È basato sul componente [Alert](https://mui.com/material-ui/react-alert/) di MUI,
+esteso dal Design System con palette semantica, icone dedicate e una CTA opzionale.
+
+Usalo per dare un feedback chiaro e immediato rispetto a un'azione o a uno stato
+del sistema, mantenendo coerenza visiva con il livello di severità comunicato.
+
+**Link utili**
+
+- 🎨 [Figma](https://www.figma.com/design/pvhsJpPGQbEwNLiyP7BOIw/MUI-Italia-Next---Design-System)
+- 💻 [GitHub](https://github.com/pagopa/mui-italia/blob/develop/src/components/MIAlert/MIAlert.tsx)
+
+## Playground
+
+<Canvas of={MIAlertStories.DefaultCTALink} />
+
+<Controls of={MIAlertStories.DefaultCTALink} />
+
+## Severità
+
+`MIAlert` supporta i quattro livelli semantici del Design System tramite la prop
+`severity`, che determina colore e icona:
+
+- **`success`** — esito positivo di un'operazione (è il default).
+- **`info`** — informazione neutra o suggerimento.
+- **`warning`** — avviso che richiede attenzione.
+- **`error`** — errore o problema bloccante.
+
+## Varianti
+
+Il componente espone due varianti tramite la prop `variant`:
+
+- **`default`** — alert riquadrato con bordo, titolo opzionale, descrizione e CTA
+  opzionale (è il default).
+- **`header`** — banda compatta a tutta larghezza, pensata per l'intestazione di
+  pagina; non ammette né titolo né azione.
+
+### Default
+
+<Canvas of={MIAlertStories.NoCTA} />
+
+### Header
+
+<Canvas of={MIAlertStories.HeaderVariant} />
+
+## Call to action
+
+Nella variante `default` è possibile aggiungere una CTA opzionale tramite la prop
+`action`, che può essere un **link** (se contiene `href`) oppure un **bottone**
+(con `onClick`).
+
+### Link
+
+<Canvas of={MIAlertStories.DefaultCTALink} />
+
+### Bottone
+
+<Canvas of={MIAlertStories.DefaultCTAClick} />
+
+## Descrizione personalizzata
+
+La prop `description` accetta sia una semplice stringa sia un `ReactNode` custom.
+Questo permette di passare contenuti più ricchi come testo formattato, link o
+liste, mantenendo lo stile dell'alert.
+
+```tsx
+<MIAlert
+  severity="error"
+  title="Titolo dell'Alert"
+  description={
+    <span>
+      Controlla i seguenti elementi:
+      <ul>
+        <li>Verifica i dati anagrafici inseriti</li>
+        <li>Controlla l'indirizzo email</li>
+        <li>
+          Consulta la <a href="https://test.com">guida online</a> per maggiori dettagli
+        </li>
+      </ul>
+    </span>
+  }
+/>
+```
+
+<Canvas of={MIAlertStories.CustomNodeDescription} />
+
+## Accessibilità
+
+Il componente `MIAlert` è basato su `Alert` di MUI, che implementa nativamente il
+pattern ARIA con `role="alert"`. Per garantire un'esperienza accessibile, segui
+queste indicazioni:
+
+- **Contenuto testuale chiaro.** Il messaggio deve essere autoesplicativo: indica
+  con precisione lo stato comunicato e, dove utile, l'azione da intraprendere.
+
+- **Non basarti solo sul colore.** La severità è veicolata anche da colore e icona,
+  ma il significato deve restare comprensibile dal solo testo, per utenti con
+  difficoltà nella percezione dei colori.
+
+- **CTA descrittive.** Se usi una `action`, l'etichetta deve descrivere chiaramente
+  l'esito dell'interazione (evita testi generici come "Clicca qui").
+
+- **Contenuti custom.** Quando passi un `ReactNode` come `description`, usa una
+  struttura semantica corretta (es. `<ul>`/`<li>` per le liste, `<a>` per i link)
+  così da preservare la navigabilità con tecnologie assistive.
+
+- **Contrasto.** Le palette semantiche del Design System garantiscono un contrasto
+  adeguato tra testo e sfondo dell'alert.

--- a/src/stories/MIAlert.stories.tsx
+++ b/src/stories/MIAlert.stories.tsx
@@ -54,7 +54,7 @@ const meta: Meta<React.ComponentProps<typeof MIAlert>> = {
       control: { type: 'text' },
       table: { type: { summary: 'string' } },
     },
-    description: {
+    children: {
       description:
         'Contenuto principale dell’alert. Accetta una semplice stringa oppure un `ReactNode` custom (es. link, liste, testo formattato).',
       control: { type: 'text' },
@@ -96,7 +96,7 @@ const withHeaderContext = (Story: React.ElementType) => (
 export const DefaultCTALink: Story = {
   args: {
     title: DEFAULT_TITLE,
-    description: DEFAULT_MESSAGE,
+    children: DEFAULT_MESSAGE,
     action: {
       label: DEFAULT_CTA,
       href: 'https://test.com',
@@ -108,7 +108,7 @@ export const DefaultCTALink: Story = {
 export const DefaultCTAClick: Story = {
   args: {
     title: DEFAULT_TITLE,
-    description: DEFAULT_MESSAGE,
+    children: DEFAULT_MESSAGE,
     action: {
       label: DEFAULT_CTA,
       onClick: () => console.log('CTA clicked'),
@@ -119,19 +119,19 @@ export const DefaultCTAClick: Story = {
 export const NoCTA: Story = {
   args: {
     title: DEFAULT_TITLE,
-    description: DEFAULT_MESSAGE,
+    children: DEFAULT_MESSAGE,
   },
 };
 
 export const NoTitle: Story = {
   args: {
-    description: DEFAULT_MESSAGE,
+    children: DEFAULT_MESSAGE,
   },
 };
 
 export const NoTitleWithCTA: Story = {
   args: {
-    description: DEFAULT_MESSAGE,
+    children: DEFAULT_MESSAGE,
     action: {
       label: DEFAULT_CTA,
       href: 'https://test.com',
@@ -143,7 +143,7 @@ export const NoTitleWithCTA: Story = {
 export const CustomNodeDescription: Story = {
   args: {
     title: DEFAULT_TITLE,
-    description: (
+    children: (
       <Box component="span">
         Non è stato possibile completare alcuni passaggi. Controlla i seguenti elementi:
         <Box component="ul" sx={{ my: 1, pl: 2.5 }}>
@@ -166,7 +166,7 @@ export const HeaderVariant: Story = {
   args: {
     variant: 'header',
     severity: 'success',
-    description:
+    children:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit auctor dui, at convallis nisl.',
   },
   decorators: [withHeaderContext],
@@ -177,7 +177,7 @@ export const HeaderVariant: Story = {
 export const StressUnbroken: Story = {
   args: {
     title: `Very long title ${LONG_UNBROKEN}`,
-    description: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
+    children: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
     action: {
       label: DEFAULT_CTA,
       href: 'https://test.com',
@@ -188,7 +188,7 @@ export const StressUnbroken: Story = {
 
 export const StressUnbrokenNoTitle: Story = {
   args: {
-    description: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
+    children: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
     action: {
       label: DEFAULT_CTA,
       href: 'https://test.com',
@@ -200,7 +200,7 @@ export const StressUnbrokenNoTitle: Story = {
 export const StressUnbrokenHeaderVariant: Story = {
   args: {
     variant: 'header',
-    description: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
+    children: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
   },
   decorators: [withHeaderContext],
 };

--- a/src/stories/MIAlert.stories.tsx
+++ b/src/stories/MIAlert.stories.tsx
@@ -31,13 +31,40 @@ const meta: Meta<React.ComponentProps<typeof MIAlert>> = {
   ],
   argTypes: {
     severity: {
+      description: 'Severità dell’alert. Determina colore e icona.',
       control: { type: 'radio' },
       options: ['success', 'error', 'info', 'warning'],
-      defaultValue: 'success',
+      table: {
+        type: { summary: "'success' | 'info' | 'warning' | 'error'" },
+        defaultValue: { summary: 'success' },
+      },
     },
-    title: { control: { type: 'text' } },
-    description: { control: { type: 'text' } },
-    action: { table: { disable: true } },
+    variant: {
+      description:
+        'Variante dell’alert. `default` mostra bordo, titolo e azione; `header` è una banda compatta a tutta larghezza senza titolo né azione.',
+      control: { type: 'radio' },
+      options: ['default', 'header'],
+      table: {
+        type: { summary: "'default' | 'header'" },
+        defaultValue: { summary: 'default' },
+      },
+    },
+    title: {
+      description: 'Titolo dell’alert. Disponibile solo per la variante `default`.',
+      control: { type: 'text' },
+      table: { type: { summary: 'string' } },
+    },
+    description: {
+      description:
+        'Contenuto principale dell’alert. Accetta una semplice stringa oppure un `ReactNode` custom (es. link, liste, testo formattato).',
+      control: { type: 'text' },
+      table: { type: { summary: 'ReactNode' } },
+    },
+    action: {
+      description:
+        'CTA opzionale (bottone o link). Disponibile solo per la variante `default`.',
+      table: { disable: true },
+    },
   },
 };
 
@@ -110,6 +137,28 @@ export const NoTitleWithCTA: Story = {
       href: 'https://test.com',
       target: '_self',
     },
+  },
+};
+
+export const CustomNodeDescription: Story = {
+  args: {
+    title: DEFAULT_TITLE,
+    description: (
+      <Box component="span">
+        Non è stato possibile completare alcuni passaggi. Controlla i seguenti elementi:
+        <Box component="ul" sx={{ my: 1, pl: 2.5 }}>
+          <li>Verifica i dati anagrafici inseriti</li>
+          <li>Controlla l’indirizzo email</li>
+          <li>
+            Consulta la{' '}
+            <Box component="a" href="https://test.com" target="_blank" rel="noopener noreferrer">
+              guida online
+            </Box>{' '}
+            per maggiori dettagli
+          </li>
+        </Box>
+      </Box>
+    ),
   },
 };
 


### PR DESCRIPTION
## Short description

MIAlert now accept a ReactNode for the description in order to use React components. Also updated the documentation.

## List of changes proposed in this pull request
- Extend MIAlert props
- Enhance documentation of MIAlert

## How to test
- Run Storybook and check documentation