### PR TITLE
fix(M20DS-30): fixed MIAlert layout on small screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/mui-italia",
-  "version": "2.6.0-RC.0",
+  "version": "2.5.0",
   "author": {
     "name": "PagoPA"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/mui-italia",
-  "version": "2.5.0",
+  "version": "2.6.0-beta.0",
   "author": {
     "name": "PagoPA"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/mui-italia",
-  "version": "2.6.0-beta.0",
+  "version": "2.6.0-RC.0",
   "author": {
     "name": "PagoPA"
   },

--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -4,9 +4,17 @@ import { ButtonNaked } from '@components/ButtonNaked';
 import { ElementType, HTMLAttributeAnchorTarget, ReactNode } from 'react';
 import { StyledAlert } from './StyledAlert';
 import { AlertTitle as MUIAlertTitle, Stack, useMediaQuery, useTheme } from '@mui/material';
-import  { AlertProps as MUIAlertProps } from '@mui/material/Alert';
+import { AlertProps as MUIAlertProps } from '@mui/material/Alert';
 import { getColor, getIcon } from './utils';
 import { AllowedAlertSeverity, MarginSxProps } from '@types';
+
+type CtaWrapSize = 'tight' | 'normal' | 'wide';
+
+const WRAP_THRESHOLDS: Record<CtaWrapSize, string> = {
+  tight: '15ch',
+  normal: '25ch',
+  wide: '40ch',
+};
 
 type ButtonCTA = {
   label: string;
@@ -28,6 +36,7 @@ interface MIAlertCtaProps {
 // Props shared by all variants
 interface BaseAlertProps extends Pick<MUIAlertProps, 'severity' | 'id'> {
   children: ReactNode;
+  ctaWrapSize?: CtaWrapSize;
   sx?: MarginSxProps;
 }
 
@@ -53,11 +62,13 @@ export const MIAlert: React.FC<MIAlertProps> = ({
   variant = 'default',
   title,
   action,
+  ctaWrapSize = 'normal',
   sx,
   ...rest
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const flexBasis = WRAP_THRESHOLDS[ctaWrapSize];
 
   return (
     <StyledAlert
@@ -70,8 +81,22 @@ export const MIAlert: React.FC<MIAlertProps> = ({
         title,
       }}
     >
-      <Stack direction={isMobile ? 'column' : 'row'} flex={1}>
-        <Stack direction="column" flex={1} minWidth={0} gap={title ? '4px' : 0}>
+      <Stack direction="row" flex={1} columnGap={8} rowGap={2} flexWrap="wrap">
+        <Stack
+          direction="column"
+          gap={title ? '4px' : 0}
+          sx={{
+            flex: {
+              xs: '1 1 100%',
+              sm: `1 1 ${flexBasis}`,
+            },
+            overflowWrap: 'anywhere',
+            backgroundColor: {
+              xs: 'red',
+              sm: 'transparent',
+            },
+          }}
+        >
           {title && <MUIAlertTitle color={getColor(theme, severity)}>{title}</MUIAlertTitle>}
           {children}
         </Stack>
@@ -104,14 +129,13 @@ const MIAlertCta = ({ cta, severity = 'success', isMobile }: Readonly<MIAlertCta
     <ButtonNaked
       {...commonProps}
       sx={(theme) => ({
-        pt: isMobile ? 2 : 0,
         minWidth: 'auto',
         fontWeight: 600,
         fontSize: '16px',
         textDecoration: 'none',
         alignSelf: isMobile ? 'flex-start' : 'center',
-        paddingLeft: isMobile ? theme.spacing(0) : theme.spacing(8),
         color: theme.colors[severity][850],
+        flexShrink: 0,
       })}
     >
       {cta.label}

--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -91,10 +91,6 @@ export const MIAlert: React.FC<MIAlertProps> = ({
               sm: `1 1 ${flexBasis}`,
             },
             overflowWrap: 'anywhere',
-            backgroundColor: {
-              xs: 'red',
-              sm: 'transparent',
-            },
           }}
         >
           {title && <MUIAlertTitle color={getColor(theme, severity)}>{title}</MUIAlertTitle>}

--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -3,7 +3,7 @@
 import { ButtonNaked } from '@components/ButtonNaked';
 import { ElementType, HTMLAttributeAnchorTarget, ReactNode } from 'react';
 import { StyledAlert } from './StyledAlert';
-import { AlertTitle as MUIAlertTitle, Stack, useMediaQuery, useTheme } from '@mui/material';
+import { Box, AlertTitle as MUIAlertTitle, Stack, useMediaQuery, useTheme } from '@mui/material';
 import { AlertProps as MUIAlertProps } from '@mui/material/Alert';
 import { getColor, getIcon } from './utils';
 import { AllowedAlertSeverity, MarginSxProps } from '@types';
@@ -82,9 +82,7 @@ export const MIAlert: React.FC<MIAlertProps> = ({
       }}
     >
       <Stack direction="row" flex={1} columnGap={8} rowGap={2} flexWrap="wrap">
-        <Stack
-          direction="column"
-          gap={title ? '4px' : 0}
+        <Box
           sx={{
             flex: {
               xs: '1 1 100%',
@@ -93,9 +91,13 @@ export const MIAlert: React.FC<MIAlertProps> = ({
             overflowWrap: 'anywhere',
           }}
         >
-          {title && <MUIAlertTitle color={getColor(theme, severity)}>{title}</MUIAlertTitle>}
+          {title && (
+            <MUIAlertTitle color={getColor(theme, severity)} sx={{ mb: '4px' }}>
+              {title}
+            </MUIAlertTitle>
+          )}
           {children}
-        </Stack>
+        </Box>
         {action && <MIAlertCta cta={action} severity={severity} isMobile={isMobile} />}
       </Stack>
     </StyledAlert>

--- a/src/components/MIAlert/StyledAlert.tsx
+++ b/src/components/MIAlert/StyledAlert.tsx
@@ -22,6 +22,7 @@ export const StyledAlert = styled(MUIAlert, {
     backgroundColor: severityPalette[100],
     justifyContent: isHeaderVariant ? 'center' : undefined,
     alignItems: isDefaultVariant || title ? 'flex-start' : 'center',
+    flex: 1,
 
     ...(isDefaultVariant && {
       border: '1px solid',

--- a/src/docs/MIAlert.mdx
+++ b/src/docs/MIAlert.mdx
@@ -88,6 +88,12 @@ più ricchi come testo formattato, link o liste, mantenendo lo stile dell'alert.
 
 <Canvas of={MIAlertStories.CustomNodeDescription} />
 
+## Adattabilità a piccole dimensioni
+
+Il componente `MIAlert` adatta la propria configurazione anche se contenuto in container piccoli.
+
+<Canvas of={MIAlertStories.LowWidth} />
+
 ## Accessibilità
 
 Il componente `MIAlert` è basato su `Alert` di MUI, che implementa nativamente il

--- a/src/docs/MIAlert.mdx
+++ b/src/docs/MIAlert.mdx
@@ -1,118 +1,186 @@
-import { Meta, Title, Controls, Canvas } from '@storybook/addon-docs/blocks';
-import * as MIAlertStories from '../stories/MIAlert.stories.tsx';
+import { Meta, Title, Primary, Controls, Story } from '@storybook/addon-docs/blocks';
+
+import Overview from './components/Overview';
+import Section from './components/Section';
+import SubSection from './components/SubSection';
+import * as MIAlertStories from '../stories/MIAlert.stories';
 
 <Meta of={MIAlertStories} />
 
 <Title />
 
-Il componente **MIAlert** comunica all'utente un messaggio di stato o una
-segnalazione contestuale (esito di un'operazione, avviso, errore o informazione).
-È basato sul componente [Alert](https://mui.com/material-ui/react-alert/) di MUI,
-esteso dal Design System con palette semantica, icone dedicate e una CTA opzionale.
+<Overview
+  githubRelativePath="MIAlert/MIAlert.tsx"
+  muiRelativePath="react-alert"
+  figmaNodeId="212-1810"
+>
+  <strong>MIAlert</strong> è un componente basato su <strong>Alert</strong> di MUI e serve a
+  mostrare messaggi di stato o segnalazioni contestuali. Supporta severità semantiche, icone
+  dedicate, una variante compatta <code>header</code>, un titolo opzionale e una CTA opzionale nella
+  variante <code>default</code>.
+</Overview>
 
-Usalo per dare un feedback chiaro e immediato rispetto a un'azione o a uno stato
-del sistema, mantenendo coerenza visiva con il livello di severità comunicato.
+<Section
+  title="Playground"
+  description="Usa i controlli per modificare le principali configurazioni del componente e verificarne il comportamento live."
+>
+  <Primary />
+  <Controls />
+</Section>
 
-**Link utili**
+<Section
+  title="Severità"
+  description="La prop severity determina colore e icona dell’alert. Se non viene indicata, il componente usa la severità success."
+>
+  <Story of={MIAlertStories.Severities} />
+</Section>
 
-- 🎨 [Figma](https://www.figma.com/design/pvhsJpPGQbEwNLiyP7BOIw/MUI-Italia-Next---Design-System)
-- 💻 [GitHub](https://github.com/pagopa/mui-italia/blob/develop/src/components/MIAlert/MIAlert.tsx)
+<Section
+  title="Varianti"
+  description="MIAlert espone due varianti: default e header. La variante default supporta titolo e CTA; la variante header non accetta né titolo né azione."
+>
+  <SubSection title="Default e header">
+    <Story of={MIAlertStories.Variants} />
+  </SubSection>
+</Section>
 
-## Playground
+<Section
+  title="Call to action"
+  description="Nella variante default è possibile aggiungere una CTA tramite la prop action. La CTA viene trattata come link quando riceve href, oppure come bottone quando riceve onClick."
+>
+  <Story of={MIAlertStories.CtaExamples} />
+</Section>
 
-<Canvas of={MIAlertStories.DefaultCTALink} />
+<Section
+  title="Layout responsive"
+  description="MIAlert può adattare la posizione della CTA alla larghezza disponibile. La prop ctaWrapSize controlla la soglia con cui contenuto e CTA vanno a capo."
+>
+  <SubSection title="Soglie CTA">
+    <p>
+      La prop <code>ctaWrapSize</code> accetta tre valori:
+    </p>
 
-<Controls of={MIAlertStories.DefaultCTALink} />
-
-## Severità
-
-`MIAlert` supporta i quattro livelli semantici del Design System tramite la prop
-`severity`, che determina colore e icona:
-
-- **`success`** — esito positivo di un'operazione (è il default).
-- **`info`** — informazione neutra o suggerimento.
-- **`warning`** — avviso che richiede attenzione.
-- **`error`** — errore o problema bloccante.
-
-## Varianti
-
-Il componente espone due varianti tramite la prop `variant`:
-
-- **`default`** — alert riquadrato con bordo, titolo opzionale, descrizione e CTA
-  opzionale (è il default).
-- **`header`** — banda compatta a tutta larghezza, pensata per l'intestazione di
-  pagina; non ammette né titolo né azione.
-
-### Default
-
-<Canvas of={MIAlertStories.NoCTA} />
-
-### Header
-
-<Canvas of={MIAlertStories.HeaderVariant} />
-
-## Call to action
-
-Nella variante `default` è possibile aggiungere una CTA opzionale tramite la prop
-`action`, che può essere un **link** (se contiene `href`) oppure un **bottone**
-(con `onClick`).
-
-### Link
-
-<Canvas of={MIAlertStories.DefaultCTALink} />
-
-### Bottone
-
-<Canvas of={MIAlertStories.DefaultCTAClick} />
-
-## Contenuto personalizzato
-
-Il contenuto principale dell'alert si passa tramite i `children`, che accettano sia
-una semplice stringa sia un `ReactNode` custom. Questo permette di passare contenuti
-più ricchi come testo formattato, link o liste, mantenendo lo stile dell'alert.
-
-```tsx
-<MIAlert severity="error" title="Titolo dell'Alert">
-  <span>
-    Controlla i seguenti elementi:
     <ul>
-      <li>Verifica i dati anagrafici inseriti</li>
-      <li>Controlla l'indirizzo email</li>
       <li>
-        Consulta la <a href="https://test.com">guida online</a> per maggiori dettagli
+        <strong>tight</strong>: usa una soglia più piccola e mantiene più facilmente la CTA sulla
+        stessa riga del contenuto.
+      </li>
+      <li>
+        <strong>normal</strong>: valore di default.
+      </li>
+      <li>
+        <strong>wide</strong>: usa una soglia più ampia e porta più facilmente la CTA sotto il
+        contenuto.
       </li>
     </ul>
-  </span>
-</MIAlert>
-```
 
-<Canvas of={MIAlertStories.CustomNodeDescription} />
+    <Story of={MIAlertStories.CtaWrapSizes} />
 
-## Adattabilità a piccole dimensioni
+  </SubSection>
 
-Il componente `MIAlert` adatta la propria configurazione anche se contenuto in container piccoli.
+  <SubSection title="Container stretto">
+    <Story of={MIAlertStories.SmallContainer} />
+  </SubSection>
+</Section>
 
-<Canvas of={MIAlertStories.LowWidth} />
+<Section
+  title="Contenuto personalizzato"
+  description="Il contenuto principale viene passato tramite children e può essere una stringa o un ReactNode."
+>
+  <SubSection title="ReactNode come children">
+    <Story of={MIAlertStories.CustomNodeDescription} />
+  </SubSection>
 
-## Accessibilità
+  <SubSection title="Esempio">
+    ```tsx
+    <MIAlert severity="error" title="Titolo dell'Alert">
+      <span>
+        Controlla i seguenti elementi:
+        <ul>
+          <li>Verifica i dati anagrafici inseriti</li>
+          <li>Controlla l'indirizzo email</li>
+          <li>
+            Consulta la <a href="https://test.com">guida online</a> per maggiori dettagli
+          </li>
+        </ul>
+      </span>
+    </MIAlert>
+    ```
+  </SubSection>
+</Section>
 
-Il componente `MIAlert` è basato su `Alert` di MUI, che implementa nativamente il
-pattern ARIA con `role="alert"`. Per garantire un'esperienza accessibile, segui
-queste indicazioni:
+<Section
+  title="Accessibilità"
+  description="MIAlert eredita il comportamento accessibile del componente Alert di MUI. L’accessibilità finale dipende anche dai contenuti passati al componente e dalla configurazione della CTA."
+>
+  <SubSection title="Props rilevanti">
+    <ul>
+      <li>
+        <strong>children</strong>: contiene il messaggio dell’alert. Deve descrivere in modo chiaro
+        lo stato o la segnalazione comunicata.
+      </li>
+      <li>
+        <strong>title</strong>: può aggiungere un’intestazione testuale nella variante{' '}
+        <code>default</code>.
+      </li>
+      <li>
+        <strong>action.label</strong>: è l’etichetta visibile della CTA. Deve descrivere l’azione
+        associata al link o al bottone.
+      </li>
+      <li>
+        <strong>action.href</strong>: quando presente, la CTA viene renderizzata come link.
+      </li>
+      <li>
+        <strong>action.onClick</strong>: quando presente senza <code>href</code>, la CTA viene
+        renderizzata come bottone.
+      </li>
+    </ul>
+  </SubSection>
 
-- **Contenuto testuale chiaro.** Il messaggio deve essere autoesplicativo: indica
-  con precisione lo stato comunicato e, dove utile, l'azione da intraprendere.
+{' '}
 
-- **Non basarti solo sul colore.** La severità è veicolata anche da colore e icona,
-  ma il significato deve restare comprensibile dal solo testo, per utenti con
-  difficoltà nella percezione dei colori.
+<SubSection title="Link in nuova scheda">
+  <p>
+    Quando la CTA è un link con <code>target="_blank"</code>, il componente imposta{' '}
+    <code>rel="noopener noreferrer"</code> se non viene fornito un valore diverso tramite la prop{' '}
+    <code>rel</code>.
+  </p>
+</SubSection>
 
-- **CTA descrittive.** Se usi una `action`, l'etichetta deve descrivere chiaramente
-  l'esito dell'interazione (evita testi generici come "Clicca qui").
+{' '}
 
-- **Contenuti custom.** Quando passi un `ReactNode` come `children`, usa una
-  struttura semantica corretta (es. `<ul>`/`<li>` per le liste, `<a>` per i link)
-  così da preservare la navigabilità con tecnologie assistive.
+<SubSection title="Varianti e props non disponibili">
+  <ul>
+    <li>
+      Nella variante <code>header</code> le props <code>title</code> e <code>action</code> non sono
+      disponibili.
+    </li>
+    <li>
+      Il componente espone solo <code>severity</code> e <code>id</code> tra le props di MUI Alert
+      tipizzate direttamente nelle props pubbliche.
+    </li>
+  </ul>
+</SubSection>
 
-- **Contrasto.** Le palette semantiche del Design System garantiscono un contrasto
-  adeguato tra testo e sfondo dell'alert.
+  <SubSection title="Esempio accessibile">
+    ```tsx
+    <MIAlert
+      severity="warning"
+      title="Dati non completi"
+      action={{
+        label: 'Completa i dati',
+        href: '/profilo/dati',
+      }}
+    >
+      Alcune informazioni obbligatorie non sono ancora state inserite.
+    </MIAlert>
+    ```
+  </SubSection>
+</Section>
+
+<Section
+  title="Stress test"
+  description="Esempio utile per verificare il comportamento del layout con testi molto lunghi o parole non spezzabili."
+>
+  <Story of={MIAlertStories.StressUnbroken} />
+</Section>

--- a/src/docs/MIAlert.mdx
+++ b/src/docs/MIAlert.mdx
@@ -77,10 +77,6 @@ import * as MIAlertStories from '../stories/MIAlert.stories';
     <Story of={MIAlertStories.CtaWrapSizes} />
 
   </SubSection>
-
-  <SubSection title="Container stretto">
-    <Story of={MIAlertStories.SmallContainer} />
-  </SubSection>
 </Section>
 
 <Section

--- a/src/docs/MIAlert.mdx
+++ b/src/docs/MIAlert.mdx
@@ -56,9 +56,8 @@ import * as MIAlertStories from '../stories/MIAlert.stories';
   description="MIAlert può adattare la posizione della CTA alla larghezza disponibile. La prop ctaWrapSize controlla la soglia con cui contenuto e CTA vanno a capo."
 >
   <SubSection title="Soglie CTA">
-    <p>
-      La prop <code>ctaWrapSize</code> accetta tre valori:
-    </p>
+    
+    La prop <code>ctaWrapSize</code> accetta tre valori:
 
     <ul>
       <li>
@@ -136,11 +135,9 @@ import * as MIAlertStories from '../stories/MIAlert.stories';
 {' '}
 
 <SubSection title="Link in nuova scheda">
-  <p>
-    Quando la CTA è un link con <code>target="_blank"</code>, il componente imposta{' '}
-    <code>rel="noopener noreferrer"</code> se non viene fornito un valore diverso tramite la prop{' '}
-    <code>rel</code>.
-  </p>
+  Quando la CTA è un link con <code>target="_blank"</code>, il componente imposta{' '}
+  <code>rel="noopener noreferrer"</code> se non viene fornito un valore diverso tramite la prop{' '}
+  <code>rel</code>.
 </SubSection>
 
 {' '}

--- a/src/stories/MIAlert.stories.tsx
+++ b/src/stories/MIAlert.stories.tsx
@@ -1,16 +1,20 @@
-import type { Meta, StoryObj } from '@storybook/react';
 import { MIAlert } from '@components/MIAlert';
-import { Box, Typography } from '@mui/material';
-import { ComponentProps } from 'react';
+import { Box, Stack, Typography } from '@mui/material';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ComponentProps } from 'react';
 
 type MIAlertStoryArgs = ComponentProps<typeof MIAlert> & {
   content?: string;
+  enableAction?: boolean;
+  actionType?: 'link' | 'button';
+  actionLabel?: string;
+  actionHref?: string;
+  openInNewTab?: boolean;
 };
 
 const DEFAULT_TITLE = "Titolo default dell'Alert";
 const DEFAULT_MESSAGE = 'Aggiungi un messaggio esplicativo sul motivo della segnalazione.';
 const DEFAULT_CTA = 'Ok, ho capito!';
-
 const LONG_UNBROKEN =
   'Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong';
 
@@ -18,20 +22,33 @@ const meta: Meta<MIAlertStoryArgs> = {
   title: 'Components/MIAlert',
   component: MIAlert,
   parameters: {
+    layout: 'padded',
     controls: {
-      include: ['variant', 'severity', 'title', 'content', 'action'],
+      include: [
+        'variant',
+        'severity',
+        'title',
+        'content',
+        'ctaWrapSize',
+        'enableAction',
+        'actionType',
+        'actionLabel',
+        'actionHref',
+        'openInNewTab',
+      ],
     },
   },
   args: {
     variant: 'default',
     severity: 'success',
-    title: "Titolo default dell'Alert",
-    content: 'Aggiungi un messaggio esplicativo sul motivo della segnalazione.',
-    action: {
-      label: 'Ok, ho capito!',
-      href: 'https://test.com',
-      target: '_blank',
-    },
+    title: DEFAULT_TITLE,
+    content: DEFAULT_MESSAGE,
+    ctaWrapSize: 'normal',
+    enableAction: true,
+    actionType: 'link',
+    actionLabel: DEFAULT_CTA,
+    actionHref: 'https://test.com',
+    openInNewTab: false,
   },
   argTypes: {
     severity: {
@@ -45,7 +62,7 @@ const meta: Meta<MIAlertStoryArgs> = {
     },
     variant: {
       description:
-        'Variante dell’alert. `default` mostra bordo, titolo e azione; `header` è una banda compatta a tutta larghezza senza titolo né azione.',
+        'Variante dell’alert. `default` supporta titolo e CTA; `header` non supporta né titolo né CTA.',
       control: { type: 'radio' },
       options: ['default', 'header'],
       table: {
@@ -56,7 +73,19 @@ const meta: Meta<MIAlertStoryArgs> = {
     title: {
       description: 'Titolo dell’alert. Disponibile solo per la variante `default`.',
       control: { type: 'text' },
-      table: { type: { summary: 'string' } },
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    ctaWrapSize: {
+      description:
+        'Soglia usata per determinare quando la CTA va a capo rispetto al contenuto: `tight`, `normal` o `wide`.',
+      control: { type: 'radio' },
+      options: ['tight', 'normal', 'wide'],
+      table: {
+        type: { summary: "'tight' | 'normal' | 'wide'" },
+        defaultValue: { summary: 'normal' },
+      },
     },
     content: {
       description: 'Controllo Storybook: testo usato come children del componente.',
@@ -65,106 +94,271 @@ const meta: Meta<MIAlertStoryArgs> = {
         category: 'Storybook controls',
       },
     },
+    enableAction: {
+      description: 'Controllo Storybook: abilita o disabilita la CTA.',
+      control: { type: 'boolean' },
+      table: {
+        category: 'Storybook controls',
+      },
+    },
+    actionType: {
+      description: 'Controllo Storybook: tipo di CTA da generare.',
+      control: { type: 'radio' },
+      options: ['link', 'button'],
+      if: { arg: 'enableAction', eq: true },
+      table: {
+        category: 'Storybook controls',
+      },
+    },
+    actionLabel: {
+      description: 'Controllo Storybook: etichetta visibile della CTA.',
+      control: { type: 'text' },
+      if: { arg: 'enableAction', eq: true },
+      table: {
+        category: 'Storybook controls',
+      },
+    },
+    actionHref: {
+      description: 'Controllo Storybook: URL usato quando la CTA è di tipo link.',
+      control: { type: 'text' },
+      if: { arg: 'enableAction', eq: true },
+      table: {
+        category: 'Storybook controls',
+      },
+    },
+    openInNewTab: {
+      description:
+        'Controllo Storybook: apre il link in una nuova scheda quando la CTA è di tipo link.',
+      control: { type: 'boolean' },
+      if: { arg: 'enableAction', eq: true },
+      table: {
+        category: 'Storybook controls',
+      },
+    },
+    children: {
+      control: false,
+      table: {
+        disable: true,
+      },
+    },
     action: {
-      description: 'CTA opzionale (bottone o link). Disponibile solo per la variante `default`.',
-      table: { disable: true },
+      control: false,
+      table: {
+        disable: true,
+      },
+    },
+    sx: {
+      control: false,
+      table: {
+        disable: true,
+      },
     },
   },
-  render: ({ content, children, sx, ...args }) => (
-    <MIAlert {...args}>
-      <Typography variant="body1">{content ?? children}</Typography>
-    </MIAlert>
-  ),
+  render: ({
+    variant = 'default',
+    severity = 'success',
+    title,
+    content,
+    ctaWrapSize = 'normal',
+    enableAction,
+    actionType,
+    actionLabel,
+    actionHref,
+    openInNewTab,
+    id,
+    children,
+  }) => {
+    const alertContent = content ?? children ?? DEFAULT_MESSAGE;
+
+    if (variant === 'header') {
+      return (
+        <MIAlert id={id} variant="header" severity={severity} ctaWrapSize={ctaWrapSize}>
+          {alertContent}
+        </MIAlert>
+      );
+    }
+
+    const action =
+      enableAction && actionLabel
+        ? actionType === 'button'
+          ? {
+              label: actionLabel,
+              onClick: () => console.log('MIAlert CTA clicked'),
+            }
+          : {
+              label: actionLabel,
+              href: actionHref,
+              target: openInNewTab ? '_blank' : '_self',
+            }
+        : undefined;
+
+    return (
+      <MIAlert
+        id={id}
+        variant="default"
+        severity={severity}
+        title={title}
+        action={action}
+        ctaWrapSize={ctaWrapSize}
+      >
+        <Typography variant="body1">{alertContent}</Typography>
+      </MIAlert>
+    );
+  },
 };
 
 export default meta;
 
 type Story = StoryObj<MIAlertStoryArgs>;
 
-const withHeaderContext = (Story: React.ElementType) => (
-  <div
-    style={{
-      padding: 0,
-      backgroundColor: '#f5f5f5',
-      border: '2px dashed #ccc',
-      minHeight: '200px',
-    }}
-  >
-    <p style={{ marginTop: 0, fontFamily: 'sans-serif', color: '#666' }}>
-      Parent Container - simula un header di pagina con larghezza limitata e sfondo diverso. L'Alert
-      dovrebbe adattarsi a questo contesto, occupando tutta la larghezza disponibile senza causare
-      overflow o problemi di layout.
-    </p>
+export const Playground: Story = {};
 
-    <Story />
-  </div>
-);
-
-const withLittleContainer = (Story: React.ElementType) => (
-  <div
-    style={{
-      width: '488px',
-    }}
-  >
-    <Story />
-  </div>
-);
-
-/* ------------------------------ Normal stories ------------------------------ */
-
-export const DefaultCTALink: Story = {
-  args: {
-    title: DEFAULT_TITLE,
-    children: DEFAULT_MESSAGE,
-    action: {
-      label: DEFAULT_CTA,
-      href: 'https://test.com',
-      target: '_self',
-    },
+export const Severities: Story = {
+  parameters: {
+    controls: { disable: true },
   },
+  render: () => (
+    <Stack spacing={2} sx={{ width: 720, maxWidth: '100%' }}>
+      {(['success', 'info', 'warning', 'error'] as const).map((severity) => (
+        <MIAlert key={severity} severity={severity} title={`Severity ${severity}`}>
+          Messaggio di esempio per la severità <strong>{severity}</strong>.
+        </MIAlert>
+      ))}
+    </Stack>
+  ),
 };
 
-export const DefaultCTAClick: Story = {
-  args: {
-    action: {
-      label: DEFAULT_CTA,
-      onClick: () => console.log('CTA clicked'),
-    },
+export const Variants: Story = {
+  parameters: {
+    controls: { disable: true },
   },
+  render: () => (
+    <Stack spacing={3} sx={{ width: 720, maxWidth: '100%' }}>
+      <Box>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          Default
+        </Typography>
+        <MIAlert severity="success" title={DEFAULT_TITLE}>
+          {DEFAULT_MESSAGE}
+        </MIAlert>
+      </Box>
+
+      <Box>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          Header
+        </Typography>
+        <MIAlert variant="header" severity="success">
+          Messaggio compatto per la variante header.
+        </MIAlert>
+      </Box>
+    </Stack>
+  ),
 };
 
-export const NoCTA: Story = {
-  args: {
-    title: DEFAULT_TITLE,
-    children: DEFAULT_MESSAGE,
+export const CtaExamples: Story = {
+  parameters: {
+    controls: { disable: true },
   },
+  render: () => (
+    <Stack spacing={2} sx={{ width: 720, maxWidth: '100%' }}>
+      <MIAlert
+        severity="info"
+        title="CTA link"
+        action={{
+          label: DEFAULT_CTA,
+          href: 'https://test.com',
+          target: '_self',
+        }}
+      >
+        La CTA viene renderizzata come link quando riceve la prop <code>href</code>.
+      </MIAlert>
+
+      <MIAlert
+        severity="warning"
+        title="CTA bottone"
+        action={{
+          label: DEFAULT_CTA,
+          onClick: () => console.log('MIAlert CTA clicked'),
+        }}
+      >
+        La CTA viene renderizzata come bottone quando riceve una callback <code>onClick</code>.
+      </MIAlert>
+    </Stack>
+  ),
+};
+
+export const CtaWrapSizes: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <Stack spacing={3} sx={{ width: 720, maxWidth: '100%' }}>
+      {(['tight', 'normal', 'wide'] as const).map((ctaWrapSize) => (
+        <Box key={ctaWrapSize}>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            ctaWrapSize: {ctaWrapSize}
+          </Typography>
+
+          <Box sx={{ width: 488, maxWidth: '100%' }}>
+            <MIAlert
+              severity="info"
+              title="Container stretto"
+              ctaWrapSize={ctaWrapSize}
+              action={{
+                label: DEFAULT_CTA,
+                href: 'https://test.com',
+              }}
+            >
+              Il contenuto dell’alert e la CTA si adattano alla larghezza disponibile del
+              contenitore.
+            </MIAlert>
+          </Box>
+        </Box>
+      ))}
+    </Stack>
+  ),
+};
+
+export const SmallContainer: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <Box sx={{ width: 488, maxWidth: '100%' }}>
+      <MIAlert
+        severity="info"
+        title="Container stretto"
+        action={{
+          label: DEFAULT_CTA,
+          href: 'https://test.com',
+        }}
+      >
+        Il layout dell’alert permette alla CTA di andare a capo quando lo spazio orizzontale non è
+        sufficiente.
+      </MIAlert>
+    </Box>
+  ),
 };
 
 export const NoTitle: Story = {
   args: {
     title: undefined,
-    children: DEFAULT_MESSAGE,
-    action: undefined,
+    enableAction: false,
   },
 };
 
-export const NoTitleWithCTA: Story = {
+export const NoCta: Story = {
   args: {
-    title: undefined,
-    children: DEFAULT_MESSAGE,
-    action: {
-      label: DEFAULT_CTA,
-      href: 'https://test.com',
-      target: '_self',
-    },
+    enableAction: false,
   },
 };
 
 export const CustomNodeDescription: Story = {
-  args: {
-    title: DEFAULT_TITLE,
-    content: undefined,
-    children: (
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <MIAlert severity="error" title="Titolo dell'Alert">
       <Box component="span">
         Non è stato possibile completare alcuni passaggi. Controlla i seguenti elementi:
         <Box component="ul" sx={{ my: 1, pl: 2.5 }}>
@@ -179,58 +373,24 @@ export const CustomNodeDescription: Story = {
           </li>
         </Box>
       </Box>
-    ),
-  },
+    </MIAlert>
+  ),
 };
-
-export const LowWidth: Story = {
-  decorators: [withLittleContainer],
-};
-
-export const HeaderVariant: Story = {
-  args: {
-    variant: 'header',
-    severity: 'success',
-    title: undefined,
-    content:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit auctor dui, at convallis nisl.',
-    action: undefined,
-  },
-  decorators: [withHeaderContext],
-};
-
-/* ------------------------------ Stress-test stories ------------------------------ */
 
 export const StressUnbroken: Story = {
-  args: {
-    title: `Very long title ${LONG_UNBROKEN}`,
-    content: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
-    action: {
-      label: DEFAULT_CTA,
-      href: 'https://test.com',
-      target: '_self',
-    },
+  parameters: {
+    controls: { disable: true },
   },
-};
-
-export const StressUnbrokenNoTitle: Story = {
-  args: {
-    title: undefined,
-    content: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
-    action: {
-      label: DEFAULT_CTA,
-      href: 'https://test.com',
-      target: '_self',
-    },
-  },
-};
-
-export const StressUnbrokenHeaderVariant: Story = {
-  args: {
-    variant: 'header',
-    title: undefined,
-    content: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
-    action: undefined,
-  },
-  decorators: [withHeaderContext],
+  render: () => (
+    <MIAlert
+      severity="warning"
+      title={`Very long title ${LONG_UNBROKEN}`}
+      action={{
+        label: DEFAULT_CTA,
+        href: 'https://test.com',
+      }}
+    >
+      {`${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`}
+    </MIAlert>
+  ),
 };

--- a/src/stories/MIAlert.stories.tsx
+++ b/src/stories/MIAlert.stories.tsx
@@ -1,9 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { breakpointsChromaticValues } from '@theme';
 import { MIAlert } from '@components/MIAlert';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
+import { ComponentProps } from 'react';
 
-const componentMaxWidth = 900;
+type MIAlertStoryArgs = ComponentProps<typeof MIAlert> & {
+  content?: string;
+};
 
 const DEFAULT_TITLE = "Titolo default dell'Alert";
 const DEFAULT_MESSAGE = 'Aggiungi un messaggio esplicativo sul motivo della segnalazione.';
@@ -12,23 +14,25 @@ const DEFAULT_CTA = 'Ok, ho capito!';
 const LONG_UNBROKEN =
   'Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong';
 
-const meta: Meta<React.ComponentProps<typeof MIAlert>> = {
-  title: 'MUI Components/Feedback/MIAlert',
+const meta: Meta<MIAlertStoryArgs> = {
+  title: 'Components/MIAlert',
   component: MIAlert,
   parameters: {
-    chromatic: {
-      viewports: breakpointsChromaticValues.filter((resolution) => resolution <= componentMaxWidth),
+    controls: {
+      include: ['variant', 'severity', 'title', 'content', 'action'],
     },
   },
-  decorators: [
-    (Story) => (
-      <Box sx={{ p: 2, pb: 4, boxSizing: 'border-box', width: '100%' }}>
-        <Box sx={{ maxWidth: '100%', mx: 'auto' }}>
-          <Story />
-        </Box>
-      </Box>
-    ),
-  ],
+  args: {
+    variant: 'default',
+    severity: 'success',
+    title: "Titolo default dell'Alert",
+    content: 'Aggiungi un messaggio esplicativo sul motivo della segnalazione.',
+    action: {
+      label: 'Ok, ho capito!',
+      href: 'https://test.com',
+      target: '_blank',
+    },
+  },
   argTypes: {
     severity: {
       description: 'Severità dell’alert. Determina colore e icona.',
@@ -54,23 +58,28 @@ const meta: Meta<React.ComponentProps<typeof MIAlert>> = {
       control: { type: 'text' },
       table: { type: { summary: 'string' } },
     },
-    children: {
-      description:
-        'Contenuto principale dell’alert. Accetta una semplice stringa oppure un `ReactNode` custom (es. link, liste, testo formattato).',
+    content: {
+      description: 'Controllo Storybook: testo usato come children del componente.',
       control: { type: 'text' },
-      table: { type: { summary: 'ReactNode' } },
+      table: {
+        category: 'Storybook controls',
+      },
     },
     action: {
-      description:
-        'CTA opzionale (bottone o link). Disponibile solo per la variante `default`.',
+      description: 'CTA opzionale (bottone o link). Disponibile solo per la variante `default`.',
       table: { disable: true },
     },
   },
+  render: ({ content, children, sx, ...args }) => (
+    <MIAlert {...args}>
+      <Typography variant="body1">{content ?? children}</Typography>
+    </MIAlert>
+  ),
 };
 
 export default meta;
 
-type Story = StoryObj<React.ComponentProps<typeof MIAlert>>;
+type Story = StoryObj<MIAlertStoryArgs>;
 
 const withHeaderContext = (Story: React.ElementType) => (
   <div
@@ -91,6 +100,16 @@ const withHeaderContext = (Story: React.ElementType) => (
   </div>
 );
 
+const withLittleContainer = (Story: React.ElementType) => (
+  <div
+    style={{
+      width: '488px',
+    }}
+  >
+    <Story />
+  </div>
+);
+
 /* ------------------------------ Normal stories ------------------------------ */
 
 export const DefaultCTALink: Story = {
@@ -107,8 +126,6 @@ export const DefaultCTALink: Story = {
 
 export const DefaultCTAClick: Story = {
   args: {
-    title: DEFAULT_TITLE,
-    children: DEFAULT_MESSAGE,
     action: {
       label: DEFAULT_CTA,
       onClick: () => console.log('CTA clicked'),
@@ -125,12 +142,15 @@ export const NoCTA: Story = {
 
 export const NoTitle: Story = {
   args: {
+    title: undefined,
     children: DEFAULT_MESSAGE,
+    action: undefined,
   },
 };
 
 export const NoTitleWithCTA: Story = {
   args: {
+    title: undefined,
     children: DEFAULT_MESSAGE,
     action: {
       label: DEFAULT_CTA,
@@ -143,6 +163,7 @@ export const NoTitleWithCTA: Story = {
 export const CustomNodeDescription: Story = {
   args: {
     title: DEFAULT_TITLE,
+    content: undefined,
     children: (
       <Box component="span">
         Non è stato possibile completare alcuni passaggi. Controlla i seguenti elementi:
@@ -162,12 +183,18 @@ export const CustomNodeDescription: Story = {
   },
 };
 
+export const LowWidth: Story = {
+  decorators: [withLittleContainer],
+};
+
 export const HeaderVariant: Story = {
   args: {
     variant: 'header',
     severity: 'success',
-    children:
+    title: undefined,
+    content:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit auctor dui, at convallis nisl.',
+    action: undefined,
   },
   decorators: [withHeaderContext],
 };
@@ -177,7 +204,7 @@ export const HeaderVariant: Story = {
 export const StressUnbroken: Story = {
   args: {
     title: `Very long title ${LONG_UNBROKEN}`,
-    children: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
+    content: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
     action: {
       label: DEFAULT_CTA,
       href: 'https://test.com',
@@ -188,7 +215,8 @@ export const StressUnbroken: Story = {
 
 export const StressUnbrokenNoTitle: Story = {
   args: {
-    children: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
+    title: undefined,
+    content: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
     action: {
       label: DEFAULT_CTA,
       href: 'https://test.com',
@@ -200,7 +228,9 @@ export const StressUnbrokenNoTitle: Story = {
 export const StressUnbrokenHeaderVariant: Story = {
   args: {
     variant: 'header',
-    children: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
+    title: undefined,
+    content: `${LONG_UNBROKEN}${LONG_UNBROKEN}${LONG_UNBROKEN}`,
+    action: undefined,
   },
   decorators: [withHeaderContext],
 };

--- a/src/stories/MIAlert.stories.tsx
+++ b/src/stories/MIAlert.stories.tsx
@@ -319,27 +319,6 @@ export const CtaWrapSizes: Story = {
   ),
 };
 
-export const SmallContainer: Story = {
-  parameters: {
-    controls: { disable: true },
-  },
-  render: () => (
-    <Box sx={{ width: 488, maxWidth: '100%' }}>
-      <MIAlert
-        severity="info"
-        title="Container stretto"
-        action={{
-          label: DEFAULT_CTA,
-          href: 'https://test.com',
-        }}
-      >
-        Il layout dell’alert permette alla CTA di andare a capo quando lo spazio orizzontale non è
-        sufficiente.
-      </MIAlert>
-    </Box>
-  ),
-};
-
 export const NoTitle: Story = {
   args: {
     title: undefined,

--- a/src/stories/MIPaper.stories.tsx
+++ b/src/stories/MIPaper.stories.tsx
@@ -1,4 +1,4 @@
-import MIPaper from '@components/MIPaper/MIPaper';
+import { MIPaper } from '@components/MIPaper';
 import { Box, Stack, Typography } from '@mui/material';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ComponentProps } from 'react';


### PR DESCRIPTION
## Short description
Apply mobile layout when MIAlert is in a tight container

## List of changes proposed in this pull request
- Added new prop called ctaWrapSize that can have three values: 'tight' | 'normal' | 'wide'. Small threshold means that the MIAlert maintains the layout with the CTA inline also in a tight container. Large threshold means that the MIAlert has the mobile layout with the CTA below the text also in a wide container.
- Added new story to simulate small container

## Product
SEND