### PR TITLE
feat(M20DS-7): introducing MIBreadcrumbs component

### DIFF
--- a/src/components/MIBreadcrumbs/MIBreadcrumbItem.tsx
+++ b/src/components/MIBreadcrumbs/MIBreadcrumbItem.tsx
@@ -1,0 +1,27 @@
+'use client'
+import { Link, Typography } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { MIBreadcrumbItemProps } from './types';
+import React from 'react';
+
+export const MIBreadcrumbItem: React.FC<MIBreadcrumbItemProps> = ({ label, onClick, href, target, current = false, type = 'regular' }) => {
+
+  const onClickHandler = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    if (onClick) {
+      e.preventDefault();
+      onClick();
+    }
+  }
+
+  return current ? (
+    <Typography className={'MIBreadcrumbItem-current'} aria-current='page'>{label}</Typography>
+  ) : <Link
+    onClick={onClickHandler}
+    underline="hover"
+    href={href}
+    target={target}
+  >
+    {type === 'back' && <ArrowBackIcon />}
+    {label}
+  </Link>;
+}

--- a/src/components/MIBreadcrumbs/MIBreadcrumbItem.tsx
+++ b/src/components/MIBreadcrumbs/MIBreadcrumbItem.tsx
@@ -1,27 +1,46 @@
-'use client'
-import { Link, Typography } from '@mui/material';
+'use client';
+import { Button, Link, Typography } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { MIBreadcrumbItemProps } from './types';
 import React from 'react';
 
-export const MIBreadcrumbItem: React.FC<MIBreadcrumbItemProps> = ({ label, onClick, href, target, current = false, type = 'regular' }) => {
+export const MIBreadcrumbItem: React.FC<MIBreadcrumbItemProps> = ({ label, onClick, href, current = false, type = 'regular', ...props } ) => {
 
-  const onClickHandler = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+  const onClickHandler = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (onClick) {
       e.preventDefault();
       onClick();
     }
   }
 
-  return current ? (
-    <Typography className={'MIBreadcrumbItem-current'} aria-current='page'>{label}</Typography>
-  ) : <Link
-    onClick={onClickHandler}
-    underline="hover"
-    href={href}
-    target={target}
-  >
-    {type === 'back' && <ArrowBackIcon />}
-    {label}
-  </Link>;
-}
+  if (current) {
+    return (
+      <Typography className={'MIBreadcrumbItem-current'} aria-current='page' {...props}>{label}</Typography>
+    );
+  }
+  if (href) {  
+    return (
+      <Link
+        underline="hover"
+        {...props}
+      >
+        {label}
+      </Link>
+    );
+  }
+  if (onClick) {
+    return (
+      <Link
+        component={Button}
+        underline="hover"
+        {...props}
+        onClick={onClickHandler}
+        type="button"
+      >
+        {type === 'back' && <ArrowBackIcon />}
+        {label}
+      </Link>
+    );
+  }
+  return null;
+};

--- a/src/components/MIBreadcrumbs/MIBreadcrumbItem.tsx
+++ b/src/components/MIBreadcrumbs/MIBreadcrumbItem.tsx
@@ -1,42 +1,42 @@
 'use client';
-import { Button, Link, Typography } from '@mui/material';
+
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import { MIBreadcrumbItemProps } from './types';
+import { Button, Link, Typography } from '@mui/material';
 import React from 'react';
+import { MIBreadcrumbItemProps } from './types';
 
-export const MIBreadcrumbItem: React.FC<MIBreadcrumbItemProps> = ({ label, onClick, href, current = false, type = 'regular', ...props } ) => {
-
+export const MIBreadcrumbItem: React.FC<MIBreadcrumbItemProps> = ({
+  label,
+  onClick,
+  href,
+  current = false,
+  type = 'regular',
+  ...props
+}) => {
   const onClickHandler = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (onClick) {
       e.preventDefault();
       onClick();
     }
-  }
+  };
 
   if (current) {
     return (
-      <Typography className={'MIBreadcrumbItem-current'} aria-current='page' {...props}>{label}</Typography>
+      <Typography className={'MIBreadcrumbItem-current'} aria-current="page" {...props}>
+        {label}
+      </Typography>
     );
   }
-  if (href) {  
+  if (href) {
     return (
-      <Link
-        underline="hover"
-        {...props}
-      >
+      <Link underline="hover" href={href} {...props}>
         {label}
       </Link>
     );
   }
   if (onClick) {
     return (
-      <Link
-        component={Button}
-        underline="hover"
-        {...props}
-        onClick={onClickHandler}
-        type="button"
-      >
+      <Link component={Button} underline="hover" {...props} onClick={onClickHandler}>
         {type === 'back' && <ArrowBackIcon />}
         {label}
       </Link>

--- a/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
+++ b/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
@@ -10,15 +10,12 @@ export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ children, backButt
   const isMobileResolution = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
 
   return (
-    <>
-      <StyledBreadcrumbs aria-label="breadcrumb" separator={<ChevronRightIcon />}>
-        {
-          isMobileResolution || variant === 'compact' ? <MIBreadcrumbItem label={backButtonLabel} type='back' onClick={backButtonAction} /> :
-            children
-        }
-      </StyledBreadcrumbs>
-    </>
-
+    <StyledBreadcrumbs aria-label="breadcrumbs" separator={<ChevronRightIcon />}>
+      {
+        isMobileResolution || variant === 'compact' ? <MIBreadcrumbItem label={backButtonLabel} type='back' onClick={backButtonAction} /> :
+          children
+      }
+    </StyledBreadcrumbs>
   );
 };
 

--- a/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
+++ b/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
@@ -6,11 +6,11 @@ import { MIBreadcrumbsProps } from './types';
 import { Theme, useMediaQuery } from '@mui/material';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
-export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ children, backButtonLabel = 'Indietro', backButtonAction = () => window.history.back(), variant = 'extended' }) => {
+export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ children, backButtonLabel = 'Indietro', backButtonAction = () => window.history.back(), variant = 'extended', ...props}) => {
   const isMobileResolution = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
 
   return (
-    <StyledBreadcrumbs aria-label="breadcrumbs" separator={<ChevronRightIcon />}>
+    <StyledBreadcrumbs aria-label="breadcrumbs" separator={<ChevronRightIcon />} {...props} >
       {
         isMobileResolution || variant === 'compact' ? <MIBreadcrumbItem label={backButtonLabel} type='back' onClick={backButtonAction} /> :
           children

--- a/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
+++ b/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
@@ -1,10 +1,31 @@
 import { StyledBreadcrumbs } from './StyledBreadcrumbs';
 import React from 'react';
 import { MIBreadcrumbsProps, MIBreadcrumbProps } from './types';
-import { Link, Theme, useMediaQuery } from '@mui/material';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { Link, Theme, useMediaQuery, SvgIconProps } from '@mui/material';
 
-const Breadcrumb: React.FC<MIBreadcrumbProps> = ({ label, showBackButton = false, onClick, href, target, }) => {
+const Breadcrumb: React.FC<MIBreadcrumbProps> = ({ label, onClick, href, target, icon }) => {
+  const [IconComponent, setIconComponent] = React.useState<React.ComponentType<SvgIconProps> | null>(null);
+
+  React.useEffect(() => {
+    if (icon) {
+      import('@mui/icons-material')
+        .then((module) => {
+          const TargetIcon = module[icon] as React.ComponentType<SvgIconProps> | undefined;
+          if (TargetIcon) {
+            setIconComponent(() => TargetIcon);
+          } else {
+            console.error(`Failed to find icon: ${icon} in @mui/icons-material`);
+            setIconComponent(null);
+          }
+        })
+        .catch((err) => {
+          console.error(`Failed to dynamically import @mui/icons-material`, err);
+          setIconComponent(null);
+        });
+    } else {
+      setIconComponent(null);
+    }
+  }, [icon]);
 
   const onClickHandler = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     if (onClick) {
@@ -22,20 +43,20 @@ const Breadcrumb: React.FC<MIBreadcrumbProps> = ({ label, showBackButton = false
       key={label}
       target={target}
     >
-      {showBackButton && <ArrowBackIcon />}
+      {icon && IconComponent && <IconComponent sx={{ mr: 1 }} />}
       {label}
     </Link>
   );
 }
 
-export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ elements, backButtonLabel = 'Indietro', variant = 'responsive', ...props }) => {
+export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ elements, mobileButtonLabel = 'Indietro', mobileButtonIcon = 'ArrowBack', variant = 'responsive' }) => {
   const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
 
   return (
     <>
-      <StyledBreadcrumbs {...props} aria-label="breadcrumb" separator="›">
+      <StyledBreadcrumbs aria-label="breadcrumb" separator="›">
         {
-          variant === 'mobileOnly' || isMobile ? <Breadcrumb label={backButtonLabel} showBackButton /> : elements?.map((element) =>
+          variant === 'mobileOnly' || isMobile ? <Breadcrumb label={mobileButtonLabel} icon={mobileButtonIcon} /> : elements?.map((element) =>
             <Breadcrumb key={element.label} {...element} />
           )
         }

--- a/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
+++ b/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
@@ -56,14 +56,14 @@ const Breadcrumb: React.FC<MIBreadcrumbProps> = ({ label, onClick, href, target,
   );
 }
 
-export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ elements, mobileButtonLabel = 'Indietro', mobileButtonIcon = 'ArrowBack', variant = 'responsive' }) => {
+export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ elements, mobileButtonLabel = 'Indietro', mobileButtonIcon = 'ArrowBack', mobileButtonAction = () => window.history.back(), variant = 'responsive' }) => {
   const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
 
   return (
     <>
       <StyledBreadcrumbs aria-label="breadcrumb" separator={<ChevronRightIcon />}>
         {
-          variant === 'mobileOnly' || isMobile ? <Breadcrumb label={mobileButtonLabel} icon={mobileButtonIcon} /> : elements?.map((element) =>
+          variant === 'mobileOnly' || isMobile ? <Breadcrumb label={mobileButtonLabel} icon={mobileButtonIcon} onClick={mobileButtonAction} /> : elements?.map((element) =>
             <Breadcrumb key={element.label} {...element} />
           )
         }

--- a/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
+++ b/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
@@ -1,71 +1,20 @@
-import { StyledBreadcrumbs } from './StyledBreadcrumbs';
+'use client';
 import React from 'react';
-import { MIBreadcrumbsProps, MIBreadcrumbProps } from './types';
-import { Link, Theme, useMediaQuery, SvgIconProps } from '@mui/material';
+import { StyledBreadcrumbs } from './StyledBreadcrumbs';
+import { MIBreadcrumbItem } from './MIBreadcrumbItem';
+import { MIBreadcrumbsProps } from './types';
+import { Theme, useMediaQuery } from '@mui/material';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
-const Breadcrumb: React.FC<MIBreadcrumbProps> = ({ label, onClick, href, target, icon, disabled = false }) => {
-  const [IconComponent, setIconComponent] = React.useState<React.ComponentType<SvgIconProps> | null>(null);
-
-  React.useEffect(() => {
-    if (icon) {
-      import('@mui/icons-material')
-        .then((module) => {
-          const TargetIcon = module[icon] as React.ComponentType<SvgIconProps> | undefined;
-          if (TargetIcon) {
-            setIconComponent(() => TargetIcon);
-          } else {
-            console.error(`Failed to find icon: ${icon} in @mui/icons-material`);
-            setIconComponent(null);
-          }
-        })
-        .catch((err) => {
-          console.error(`Failed to dynamically import @mui/icons-material`, err);
-          setIconComponent(null);
-        });
-    } else {
-      setIconComponent(null);
-    }
-  }, [icon]);
-
-  const onClickHandler = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-    if (disabled) {
-      e.preventDefault();
-      return;
-    }
-
-    if (onClick) {
-      e.preventDefault();
-      onClick();
-    }
-  }
-
-  return (
-    <Link
-      className={disabled ? 'MuiLink-disabled' : ''}
-      onClick={onClickHandler}
-      underline="hover"
-      aria-current="page"
-      href={href}
-      key={label}
-      target={target}
-    >
-      {icon && IconComponent && <IconComponent />}
-      {label}
-    </Link>
-  );
-}
-
-export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ elements, mobileButtonLabel = 'Indietro', mobileButtonIcon = 'ArrowBack', mobileButtonAction = () => window.history.back(), variant = 'responsive' }) => {
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
+export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ children, backButtonLabel = 'Indietro', backButtonAction = () => window.history.back(), variant = 'extended' }) => {
+  const isMobileResolution = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
 
   return (
     <>
       <StyledBreadcrumbs aria-label="breadcrumb" separator={<ChevronRightIcon />}>
         {
-          variant === 'mobileOnly' || isMobile ? <Breadcrumb label={mobileButtonLabel} icon={mobileButtonIcon} onClick={mobileButtonAction} /> : elements?.map((element) =>
-            <Breadcrumb key={element.label} {...element} />
-          )
+          isMobileResolution || variant === 'compact' ? <MIBreadcrumbItem label={backButtonLabel} type='back' onClick={backButtonAction} /> :
+            children
         }
       </StyledBreadcrumbs>
     </>

--- a/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
+++ b/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
@@ -1,0 +1,37 @@
+import { StyledBreadcrumbs } from './StyledBreadcrumbs';
+import React from 'react';
+import { MIBreadcrumbsProps, MIBreadcrumb } from './types';
+import { Link, Theme, useMediaQuery } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+
+const Breadcrumb: React.FC<MIBreadcrumb> = ({ label, showBackButton = false }) => {
+  return (
+    <Link
+      underline="hover"
+      aria-current="page"
+      href="#"
+      key={label}
+    >
+      {showBackButton && <ArrowBackIcon />}
+      {label}
+    </Link>
+  );
+}
+
+export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ breadcrumbs, backButtonLabel = 'Indietro', variant = 'default', ...props }) => {
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
+
+  return (
+    <>
+      <StyledBreadcrumbs {...props} aria-label="breadcrumb" separator="›">
+        {
+          variant === 'wizard' || isMobile ? <Breadcrumb label={backButtonLabel} showBackButton /> : breadcrumbs?.map((breadcrumb) =>
+            <Breadcrumb key={breadcrumb.label} {...breadcrumb} />
+          )
+        }
+      </StyledBreadcrumbs>
+    </>
+
+  );
+};
+

--- a/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
+++ b/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
@@ -2,8 +2,9 @@ import { StyledBreadcrumbs } from './StyledBreadcrumbs';
 import React from 'react';
 import { MIBreadcrumbsProps, MIBreadcrumbProps } from './types';
 import { Link, Theme, useMediaQuery, SvgIconProps } from '@mui/material';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
-const Breadcrumb: React.FC<MIBreadcrumbProps> = ({ label, onClick, href, target, icon }) => {
+const Breadcrumb: React.FC<MIBreadcrumbProps> = ({ label, onClick, href, target, icon, disabled = false }) => {
   const [IconComponent, setIconComponent] = React.useState<React.ComponentType<SvgIconProps> | null>(null);
 
   React.useEffect(() => {
@@ -28,6 +29,11 @@ const Breadcrumb: React.FC<MIBreadcrumbProps> = ({ label, onClick, href, target,
   }, [icon]);
 
   const onClickHandler = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    if (disabled) {
+      e.preventDefault();
+      return;
+    }
+
     if (onClick) {
       e.preventDefault();
       onClick();
@@ -36,6 +42,7 @@ const Breadcrumb: React.FC<MIBreadcrumbProps> = ({ label, onClick, href, target,
 
   return (
     <Link
+      className={disabled ? 'MuiLink-disabled' : ''}
       onClick={onClickHandler}
       underline="hover"
       aria-current="page"
@@ -43,7 +50,7 @@ const Breadcrumb: React.FC<MIBreadcrumbProps> = ({ label, onClick, href, target,
       key={label}
       target={target}
     >
-      {icon && IconComponent && <IconComponent sx={{ mr: 1 }} />}
+      {icon && IconComponent && <IconComponent />}
       {label}
     </Link>
   );
@@ -54,7 +61,7 @@ export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ elements, mobileBu
 
   return (
     <>
-      <StyledBreadcrumbs aria-label="breadcrumb" separator="›">
+      <StyledBreadcrumbs aria-label="breadcrumb" separator={<ChevronRightIcon />}>
         {
           variant === 'mobileOnly' || isMobile ? <Breadcrumb label={mobileButtonLabel} icon={mobileButtonIcon} /> : elements?.map((element) =>
             <Breadcrumb key={element.label} {...element} />

--- a/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
+++ b/src/components/MIBreadcrumbs/MIBreadcrumbs.tsx
@@ -1,16 +1,26 @@
 import { StyledBreadcrumbs } from './StyledBreadcrumbs';
 import React from 'react';
-import { MIBreadcrumbsProps, MIBreadcrumb } from './types';
+import { MIBreadcrumbsProps, MIBreadcrumbProps } from './types';
 import { Link, Theme, useMediaQuery } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
-const Breadcrumb: React.FC<MIBreadcrumb> = ({ label, showBackButton = false }) => {
+const Breadcrumb: React.FC<MIBreadcrumbProps> = ({ label, showBackButton = false, onClick, href, target, }) => {
+
+  const onClickHandler = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    if (onClick) {
+      e.preventDefault();
+      onClick();
+    }
+  }
+
   return (
     <Link
+      onClick={onClickHandler}
       underline="hover"
       aria-current="page"
-      href="#"
+      href={href}
       key={label}
+      target={target}
     >
       {showBackButton && <ArrowBackIcon />}
       {label}
@@ -18,15 +28,15 @@ const Breadcrumb: React.FC<MIBreadcrumb> = ({ label, showBackButton = false }) =
   );
 }
 
-export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ breadcrumbs, backButtonLabel = 'Indietro', variant = 'default', ...props }) => {
+export const MIBreadcrumbs: React.FC<MIBreadcrumbsProps> = ({ elements, backButtonLabel = 'Indietro', variant = 'responsive', ...props }) => {
   const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
 
   return (
     <>
       <StyledBreadcrumbs {...props} aria-label="breadcrumb" separator="›">
         {
-          variant === 'wizard' || isMobile ? <Breadcrumb label={backButtonLabel} showBackButton /> : breadcrumbs?.map((breadcrumb) =>
-            <Breadcrumb key={breadcrumb.label} {...breadcrumb} />
+          variant === 'mobileOnly' || isMobile ? <Breadcrumb label={backButtonLabel} showBackButton /> : elements?.map((element) =>
+            <Breadcrumb key={element.label} {...element} />
           )
         }
       </StyledBreadcrumbs>

--- a/src/components/MIBreadcrumbs/StyledBreadcrumbs.tsx
+++ b/src/components/MIBreadcrumbs/StyledBreadcrumbs.tsx
@@ -1,0 +1,24 @@
+import { styled } from '@mui/material';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+
+export const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => {
+  return {
+    height: '22px',
+    lineHeight: '22px',
+    fontWeight: 500,
+    '& .MuiBreadcrumbs-li svg': {
+      fontSize: '24px',
+    },
+    '& .MuiLink-root.MuiLink-underlineHover': {
+      display: 'flex',
+      marginTop: 0,
+      marginBottom: 0,
+      padding: 0,
+      color: theme.colors.neutral.black,
+      '&:hover': {
+        color: theme.colors.blue[500],
+        textDecoration: 'underline !important'
+      },
+    },
+  };
+});

--- a/src/components/MIBreadcrumbs/StyledBreadcrumbs.tsx
+++ b/src/components/MIBreadcrumbs/StyledBreadcrumbs.tsx
@@ -17,7 +17,8 @@ export const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => {
       color: theme.colors.neutral.black,
       '&:hover': {
         color: theme.colors.blue[500],
-        textDecoration: 'underline !important'
+        textDecoration: 'underline',
+        cursor: 'pointer',
       },
     },
   };

--- a/src/components/MIBreadcrumbs/StyledBreadcrumbs.tsx
+++ b/src/components/MIBreadcrumbs/StyledBreadcrumbs.tsx
@@ -3,11 +3,13 @@ import Breadcrumbs from '@mui/material/Breadcrumbs';
 
 export const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => {
   return {
-    height: '22px',
-    lineHeight: '22px',
     fontWeight: 500,
+    '& .MuiBreadcrumbs-separator svg': {
+      fontSize: "16px",
+      color: theme.colors.neutral.black,
+    },
     '& .MuiBreadcrumbs-li svg': {
-      fontSize: '24px',
+      fontSize: "24px",
     },
     '& .MuiLink-root.MuiLink-underlineHover': {
       display: 'flex',
@@ -15,10 +17,14 @@ export const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => {
       marginBottom: 0,
       padding: 0,
       color: theme.colors.neutral.black,
-      '&:hover': {
+      '&:hover:not(.MuiLink-disabled)': {
         color: theme.colors.blue[500],
         textDecoration: 'underline',
         cursor: 'pointer',
+      },
+      '&.MuiLink-disabled': {
+        cursor: 'not-allowed',
+        color: theme.colors.neutral.grey[450],
       },
     },
   };

--- a/src/components/MIBreadcrumbs/StyledBreadcrumbs.tsx
+++ b/src/components/MIBreadcrumbs/StyledBreadcrumbs.tsx
@@ -3,13 +3,16 @@ import Breadcrumbs from '@mui/material/Breadcrumbs';
 
 export const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => {
   return {
+    '& .MIBreadcrumbItem-current': {
+      color: theme.colors.neutral.grey[700],
+    },
     fontWeight: 500,
     '& .MuiBreadcrumbs-separator svg': {
-      fontSize: "16px",
+      fontSize: theme.typography.pxToRem(16),
       color: theme.colors.neutral.black,
     },
     '& .MuiBreadcrumbs-li svg': {
-      fontSize: "24px",
+      fontSize: theme.typography.pxToRem(24),
     },
     '& .MuiLink-root.MuiLink-underlineHover': {
       display: 'flex',
@@ -21,10 +24,6 @@ export const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => {
         color: theme.colors.blue[500],
         textDecoration: 'underline',
         cursor: 'pointer',
-      },
-      '&.MuiLink-disabled': {
-        cursor: 'not-allowed',
-        color: theme.colors.neutral.grey[450],
       },
     },
   };

--- a/src/components/MIBreadcrumbs/index.ts
+++ b/src/components/MIBreadcrumbs/index.ts
@@ -1,1 +1,2 @@
 export * from './MIBreadcrumbs';
+export * from './MIBreadcrumbItem';

--- a/src/components/MIBreadcrumbs/index.ts
+++ b/src/components/MIBreadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export * from './MIBreadcrumbs';

--- a/src/components/MIBreadcrumbs/types.ts
+++ b/src/components/MIBreadcrumbs/types.ts
@@ -22,8 +22,8 @@ export interface MIBreadcrumbsProps {
    */
   mobileButtonLabel?: string;
   /**
-   * Nome dell'icona da importare da @mui/icons-material da usare nel bottone "Indietro".
-   * E.g. 'Home', 'ArrowBack', etc.
+   * Nome dell'icona da importare da "@mui/icons-material" da usare nel bottone "Indietro".
+   * @default "ArrowBack"
    */
   mobileButtonIcon?: MIIconName;
   /**

--- a/src/components/MIBreadcrumbs/types.ts
+++ b/src/components/MIBreadcrumbs/types.ts
@@ -1,0 +1,25 @@
+type BreadcrumbsVariant = 'default' | 'wizard';
+
+export interface MIBreadcrumbsProps {
+  breadcrumbs?: MIBreadcrumb[];
+  /**
+   * Etichetta del bottone "Indietro"
+   * @default "Indietro"
+   * utilizzare string vuota per nascondere l'etichetta e mostrare solo l'icona di back
+   * oppure è possibile valorizzare la prop per gestire le traduzioni 
+   */
+  backButtonLabel?: string;
+  /**
+   * Variante del breadcrumb
+   * @default "default"
+   * - "default": breadcrumb standard
+   * - "wizard": breadcrumb con bottone "Indietro"
+   */
+  variant?: BreadcrumbsVariant;
+}
+
+
+export interface MIBreadcrumb {
+  label: string;
+  showBackButton?: boolean;
+}

--- a/src/components/MIBreadcrumbs/types.ts
+++ b/src/components/MIBreadcrumbs/types.ts
@@ -1,10 +1,12 @@
 
 import { BreadcrumbsOwnProps } from '@mui/material/Breadcrumbs/Breadcrumbs';
-import { ReactElement } from 'react';
+import { LinkProps } from '@mui/material/Link';
+import { TypographyProps } from '@mui/material/Typography';
+import { ComponentPropsWithoutRef, ReactElement } from 'react';
 
 type MIBreadcrumbsVariant = 'extended' | 'compact';
 
-export interface MIBreadcrumbsProps extends Pick<BreadcrumbsOwnProps, 'children'> {
+export interface MIBreadcrumbsProps extends ComponentPropsWithoutRef<'nav'>, Pick<BreadcrumbsOwnProps, 'sx'> {
   /**
    * Array di componenti MIBreadcrumbItem
    * L'ordine degli elementi è importante e deve rispecchiare l'ordine gerarchico di navigazione.
@@ -39,34 +41,39 @@ export interface MIBreadcrumbsProps extends Pick<BreadcrumbsOwnProps, 'children'
   variant?: MIBreadcrumbsVariant;
 }
 
-export interface MIBreadcrumbItemProps {
-  /**
-   * Etichetta del breadcrumb.
-   */
+type BaseMIBreadcrumbItemProps = {
   label: string;
-  /**
-   * Callback che viene eseguita quando l'elemento viene cliccato.
-   * Se non specificato, l'elemento non sarà cliccabile.
-   */
-  onClick?: () => void;
-  /**
-   * Target dell'elemento (solo se href è specificato).
-   */
-  target?: React.HTMLAttributeAnchorTarget;
-  /**
-   * URL a cui punta l'elemento (solo se onClick non è specificato).
-   */
-  href?: string;
-  /**
-   * Se true, l'elemento è l'elemento corrente (non cliccabile e con stile non attivo).
-   * @default false
-   */
-  current?: boolean;
-  /**
-   * Tipo di elemento.
-   * @default "regular"
-   * - "regular": elemento regolare
-   * - "back": elemento di tipo "back"
-   */
   type?: 'regular' | 'back';
-}
+};
+
+type CurrentBreadcrumbItemProps =
+  BaseMIBreadcrumbItemProps &
+  Pick<TypographyProps, 'sx'> & {
+    current: true;
+    href?: never;
+    onClick?: never;
+    target?: never;
+    rel?: never;
+  };
+
+type LinkBreadcrumbItemProps =
+  BaseMIBreadcrumbItemProps &
+  Pick<LinkProps, 'href' | 'target' | 'rel' | 'sx'> & {
+    current?: false;
+    onClick?: never;
+  };
+
+type ActionBreadcrumbItemProps =
+  BaseMIBreadcrumbItemProps &
+  Pick<LinkProps, 'sx'> & {
+    current?: false;
+    onClick: () => void;
+    href?: never;
+    target?: never;
+    rel?: never;
+  };
+
+export type MIBreadcrumbItemProps =
+  | CurrentBreadcrumbItemProps
+  | LinkBreadcrumbItemProps
+  | ActionBreadcrumbItemProps;

--- a/src/components/MIBreadcrumbs/types.ts
+++ b/src/components/MIBreadcrumbs/types.ts
@@ -1,4 +1,8 @@
+import type * as Icons from '@mui/icons-material';
+
 type BreadcrumbsVariant = 'responsive' | 'mobileOnly';
+
+export type MIIconName = keyof typeof Icons;
 
 export interface MIBreadcrumbsProps {
   /**
@@ -16,7 +20,12 @@ export interface MIBreadcrumbsProps {
    * - utilizzare string vuota per nascondere l'etichetta e mostrare solo l'icona di back
    * - oppure è possibile valorizzare la prop per gestire le traduzioni 
    */
-  backButtonLabel?: string;
+  mobileButtonLabel?: string;
+  /**
+   * Nome dell'icona da importare da @mui/icons-material da usare nel bottone "Indietro".
+   * E.g. 'Home', 'ArrowBack', etc.
+   */
+  mobileButtonIcon?: MIIconName;
   /**
    * Variante del breadcrumb
    * @default "responsive"
@@ -28,8 +37,21 @@ export interface MIBreadcrumbsProps {
 
 export interface MIBreadcrumbProps {
   label: string;
-  showBackButton?: boolean;
+  /**
+   * Callback che viene eseguita quando l'elemento viene cliccato.
+   * Se non specificato, l'elemento non sarà cliccabile.
+   */
   onClick?: () => void;
   target?: React.HTMLAttributeAnchorTarget;
   href?: string;
+  /**
+   * Nome dell'icona da importare da @mui/icons-material.
+   * E.g. 'Home', 'ArrowBack', etc.
+   */
+  icon?: MIIconName;
+  /**
+   * Se true, l'elemento è disattivo (non cliccabile e con stile non attivo).
+   * @default false
+   */
+  disabled?: boolean;
 }

--- a/src/components/MIBreadcrumbs/types.ts
+++ b/src/components/MIBreadcrumbs/types.ts
@@ -27,6 +27,11 @@ export interface MIBreadcrumbsProps {
    */
   mobileButtonIcon?: MIIconName;
   /**
+   * Callback che viene eseguita quando il bottone "Indietro" viene cliccato.
+   * @default () => window.history.back()
+   */
+  mobileButtonAction?: () => void;
+  /**
    * Variante del breadcrumb
    * @default "responsive"
    * - "responsive": breadcrumb responsive per mobile e desktop

--- a/src/components/MIBreadcrumbs/types.ts
+++ b/src/components/MIBreadcrumbs/types.ts
@@ -1,17 +1,21 @@
-import type * as Icons from '@mui/icons-material';
 
-type BreadcrumbsVariant = 'responsive' | 'mobileOnly';
+import { BreadcrumbsOwnProps } from '@mui/material/Breadcrumbs/Breadcrumbs';
+import { ReactElement } from 'react';
 
-export type MIIconName = keyof typeof Icons;
+type MIBreadcrumbsVariant = 'extended' | 'compact';
 
-export interface MIBreadcrumbsProps {
+export interface MIBreadcrumbsProps extends Pick<BreadcrumbsOwnProps, 'children'> {
   /**
-   * Array di elementi delle breadcrumbs.
-   * Ogni elemento rappresenta un elemento della gerarchia di navigazione.
+   * Array di componenti MIBreadcrumbItem
    * L'ordine degli elementi è importante e deve rispecchiare l'ordine gerarchico di navigazione.
-   * Esempio: Home - Elenco Ricevute - Dettaglio Ricevuta
+   * Esempio: 
+   * <MIBreadcrumbs>
+   *  <MIBreadcrumbItem label="Home" href="/" />
+   *  <MIBreadcrumbItem label="Elenco Ricevute" href="/ricevute" />
+   *  <MIBreadcrumbItem label="Dettaglio Ricevuta" current/>
+   * </MIBreadcrumbs>
    */
-  elements?: MIBreadcrumbProps[];
+  children?: ReactElement<MIBreadcrumbItemProps>[];
   /**
    * Etichetta del bottone "Indietro".
    * Visibile sempre nella variante 'mobileOnly',
@@ -20,43 +24,49 @@ export interface MIBreadcrumbsProps {
    * - utilizzare string vuota per nascondere l'etichetta e mostrare solo l'icona di back
    * - oppure è possibile valorizzare la prop per gestire le traduzioni 
    */
-  mobileButtonLabel?: string;
-  /**
-   * Nome dell'icona da importare da "@mui/icons-material" da usare nel bottone "Indietro".
-   * @default "ArrowBack"
-   */
-  mobileButtonIcon?: MIIconName;
+  backButtonLabel?: string;
   /**
    * Callback che viene eseguita quando il bottone "Indietro" viene cliccato.
    * @default () => window.history.back()
    */
-  mobileButtonAction?: () => void;
+  backButtonAction?: () => void;
   /**
-   * Variante del breadcrumb
-   * @default "responsive"
-   * - "responsive": breadcrumb responsive per mobile e desktop
-   * - "mobileOnly": breadcrumb solo per mobile
+   * Variante delle breadcrumbs
+   * @default "extended"
+   * - "extended": breadcrumbs responsive per mobile e desktop
+   * - "compact": viene mostrato solo il pulsante indietro e i children del breadcrumb vengono omessi (se presenti)
    */
-  variant?: BreadcrumbsVariant;
+  variant?: MIBreadcrumbsVariant;
 }
 
-export interface MIBreadcrumbProps {
+export interface MIBreadcrumbItemProps {
+  /**
+   * Etichetta del breadcrumb.
+   */
   label: string;
   /**
    * Callback che viene eseguita quando l'elemento viene cliccato.
    * Se non specificato, l'elemento non sarà cliccabile.
    */
   onClick?: () => void;
+  /**
+   * Target dell'elemento (solo se href è specificato).
+   */
   target?: React.HTMLAttributeAnchorTarget;
+  /**
+   * URL a cui punta l'elemento (solo se onClick non è specificato).
+   */
   href?: string;
   /**
-   * Nome dell'icona da importare da @mui/icons-material.
-   * E.g. 'Home', 'ArrowBack', etc.
-   */
-  icon?: MIIconName;
-  /**
-   * Se true, l'elemento è disattivo (non cliccabile e con stile non attivo).
+   * Se true, l'elemento è l'elemento corrente (non cliccabile e con stile non attivo).
    * @default false
    */
-  disabled?: boolean;
+  current?: boolean;
+  /**
+   * Tipo di elemento.
+   * @default "regular"
+   * - "regular": elemento regolare
+   * - "back": elemento di tipo "back"
+   */
+  type?: 'regular' | 'back';
 }

--- a/src/components/MIBreadcrumbs/types.ts
+++ b/src/components/MIBreadcrumbs/types.ts
@@ -1,25 +1,35 @@
-type BreadcrumbsVariant = 'default' | 'wizard';
+type BreadcrumbsVariant = 'responsive' | 'mobileOnly';
 
 export interface MIBreadcrumbsProps {
-  breadcrumbs?: MIBreadcrumb[];
   /**
-   * Etichetta del bottone "Indietro"
+   * Array di elementi delle breadcrumbs.
+   * Ogni elemento rappresenta un elemento della gerarchia di navigazione.
+   * L'ordine degli elementi è importante e deve rispecchiare l'ordine gerarchico di navigazione.
+   * Esempio: Home - Elenco Ricevute - Dettaglio Ricevuta
+   */
+  elements?: MIBreadcrumbProps[];
+  /**
+   * Etichetta del bottone "Indietro".
+   * Visibile sempre nella variante 'mobileOnly',
+   * altrimenti visibile per risoluzioni mobile.
    * @default "Indietro"
-   * utilizzare string vuota per nascondere l'etichetta e mostrare solo l'icona di back
-   * oppure è possibile valorizzare la prop per gestire le traduzioni 
+   * - utilizzare string vuota per nascondere l'etichetta e mostrare solo l'icona di back
+   * - oppure è possibile valorizzare la prop per gestire le traduzioni 
    */
   backButtonLabel?: string;
   /**
    * Variante del breadcrumb
-   * @default "default"
-   * - "default": breadcrumb standard
-   * - "wizard": breadcrumb con bottone "Indietro"
+   * @default "responsive"
+   * - "responsive": breadcrumb responsive per mobile e desktop
+   * - "mobileOnly": breadcrumb solo per mobile
    */
   variant?: BreadcrumbsVariant;
 }
 
-
-export interface MIBreadcrumb {
+export interface MIBreadcrumbProps {
   label: string;
   showBackButton?: boolean;
+  onClick?: () => void;
+  target?: React.HTMLAttributeAnchorTarget;
+  href?: string;
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -44,3 +44,4 @@ export * from './MISnackbar';
 export * from './MIPaper';
 export * from './MIBoxedModule';
 export * from './MIStepper';
+export * from './MIBreadcrumbs';

--- a/src/docs/MIBreadcrumbs.mdx
+++ b/src/docs/MIBreadcrumbs.mdx
@@ -30,8 +30,8 @@ import * as MIBreadcrumbsStories from '../stories/MIBreadcrumbs.stories.tsx';
 
 <Section
   title="Varianti"
-  description="MIBreadcrumbs supporta due varianti: responsive e mobileOnly.
-  Nella variante mobileOnly, indipendentemente dal numero di elementi delle breadcrumbs e dalla risoluzione,
+  description="MIBreadcrumbs supporta due varianti: extended e compact.
+  Nella variante compact, indipendentemente dal numero di elementi delle breadcrumbs e dalla risoluzione,
   viene mostrata solo il pulsante 'Indietro'. (Il cui testo è personalizzabile)"
 >
   <Story of={MIBreadcrumbsStories.Variants} />
@@ -48,21 +48,17 @@ import * as MIBreadcrumbsStories from '../stories/MIBreadcrumbs.stories.tsx';
     <pre>
     ```js filename="index.js"
     ...
-    import { MIBreadcrumbs } from 'components/MIBreadcrumbs';
+    import { MIBreadcrumbs, MIBreadcrumbItem } from 'components/MIBreadcrumbs';
     import { useNavigate } from 'react-router-dom';
     ...
     const navigate = useNavigate();
     ...
     return (
-      <MIBreadcrumbs
-        breadcrumbs={
-          [
-            { label: 'Home', onClick: () => navigate('/') },
-            { label: 'About', onClick: () => navigate('/about') }
-            { label: 'Contact', onClick: () => navigate('/about/contact') }
-          ]
-        }
-      />
+      <MIBreadcrumbs>
+        <MIBreadcrumbItem label="Home" onClick={() => navigate('/')} />
+        <MIBreadcrumbItem label="About" onClick={() => navigate('/about')} />
+        <MIBreadcrumbItem label="Contact" current/>
+      </MIBreadcrumbs>
     )
     ...
     ```

--- a/src/docs/MIBreadcrumbs.mdx
+++ b/src/docs/MIBreadcrumbs.mdx
@@ -30,9 +30,43 @@ import * as MIBreadcrumbsStories from '../stories/MIBreadcrumbs.stories.tsx';
 
 <Section
   title="Varianti"
-  description="MIBreadcrumbs supporta due varianti: default e wizard.
-  Nella variante wizard, indipendentemente dal numero di breadcrumbs e dalla risoluzione,
+  description="MIBreadcrumbs supporta due varianti: responsive e mobileOnly.
+  Nella variante mobileOnly, indipendentemente dal numero di elementi delle breadcrumbs e dalla risoluzione,
   viene mostrata solo il pulsante 'Indietro'. (Il cui testo è personalizzabile)"
 >
   <Story of={MIBreadcrumbsStories.Variants} />
+</Section>
+
+
+<Section
+  title="Routing"
+  description="MIBreadcrumbs supporta due modalità di routing: Link e OnClick."
+>
+  Per sfruttare la navigazione standard basata su URL, è necessario specificare la prop href. 
+  Per sfruttare la navigazione personalizzata, è necessario specificare la prop onClick.
+  Segue un esempio di implementazione che sfrutta la navigazione client side di react-router-dom:
+
+    <pre>
+    ```js filename="index.js"
+    ...
+    import { MIBreadcrumbs } from 'components/MIBreadcrumbs';
+    import { useNavigate } from 'react-router-dom';
+    ...
+    const navigate = useNavigate();
+    ...
+    return (
+      <MIBreadcrumbs
+        breadcrumbs={
+          [
+            { label: 'Home', onClick: () => navigate('/') },
+            { label: 'About', onClick: () => navigate('/about') }
+            { label: 'Contact', onClick: () => navigate('/about/contact') }
+          ]
+        }
+      />
+    )
+    ...
+    ```
+    </pre>
+    Se entrambe le modalità sono state specificate, prevale onClick (tramite un preventDefault sull'evento click).
 </Section>

--- a/src/docs/MIBreadcrumbs.mdx
+++ b/src/docs/MIBreadcrumbs.mdx
@@ -1,0 +1,38 @@
+import { Meta, Title, Primary, Controls, Story } from '@storybook/addon-docs/blocks';
+import { Typography } from '@mui/material';
+
+import Overview from './components/Overview';
+import Section from './components/Section';   
+import * as MIBreadcrumbsStories from '../stories/MIBreadcrumbs.stories.tsx';
+
+<Meta of={MIBreadcrumbsStories} />
+
+<Title />
+
+<Overview
+  githubRelativePath={'MIBreadcrumbs/MIBreadcrumbs.tsx'}
+  figmaNodeId={'1-21'}
+  muiRelativePath={'react-breadcrumbs'}
+>
+  Il componente <strong>MIBreadcrumbs</strong> è utilizzato per mostrare la gerarchia
+  delle pagine e la posizione attuale dell'utente all'interno del prodotto.
+  È basato sul componente [Breadcrumbs](https://mui.com/material-ui/react-breadcrumbs/) di MUI,
+  opportunamente semplificato e adatto alle esigenze del design system MUI Italia Next.
+</Overview>
+
+<Section
+  title="Playground"
+  description="Usa i controlli per modificare i parametri principali del componente e verificare il risultato live."
+>
+  <Primary />
+  <Controls />
+</Section>
+
+<Section
+  title="Varianti"
+  description="MIBreadcrumbs supporta due varianti: default e wizard.
+  Nella variante wizard, indipendentemente dal numero di breadcrumbs e dalla risoluzione,
+  viene mostrata solo il pulsante 'Indietro'. (Il cui testo è personalizzabile)"
+>
+  <Story of={MIBreadcrumbsStories.Variants} />
+</Section>

--- a/src/docs/MIBreadcrumbs.mdx
+++ b/src/docs/MIBreadcrumbs.mdx
@@ -1,8 +1,8 @@
 import { Meta, Title, Primary, Controls, Story } from '@storybook/addon-docs/blocks';
-import { Typography } from '@mui/material';
 
 import Overview from './components/Overview';
-import Section from './components/Section';   
+import Section from './components/Section';
+import SubSection from './components/SubSection';
 import * as MIBreadcrumbsStories from '../stories/MIBreadcrumbs.stories.tsx';
 
 <Meta of={MIBreadcrumbsStories} />
@@ -10,58 +10,238 @@ import * as MIBreadcrumbsStories from '../stories/MIBreadcrumbs.stories.tsx';
 <Title />
 
 <Overview
-  githubRelativePath={'MIBreadcrumbs/MIBreadcrumbs.tsx'}
-  figmaNodeId={'1-21'}
-  muiRelativePath={'react-breadcrumbs'}
+  githubRelativePath="MIBreadcrumbs/MIBreadcrumbs.tsx"
+  figmaNodeId="1-21"
+  muiRelativePath="react-breadcrumbs"
 >
-  Il componente <strong>MIBreadcrumbs</strong> è utilizzato per mostrare la gerarchia
-  delle pagine e la posizione attuale dell'utente all'interno del prodotto.
-  È basato sul componente [Breadcrumbs](https://mui.com/material-ui/react-breadcrumbs/) di MUI,
-  opportunamente semplificato e adatto alle esigenze del design system MUI Italia Next.
+  <strong>MIBreadcrumbs</strong> è un componente di navigazione basato su Breadcrumbs di MUI. Mostra
+  una sequenza ordinata di <code>MIBreadcrumbItem</code> per rappresentare la gerarchia delle pagine
+  e identifica la pagina corrente. Gli elementi precedenti possono essere configurati come link
+  oppure come azioni. Il componente può mostrare la gerarchia completa o un singolo pulsante
+  Indietro e adatta automaticamente la presentazione alle risoluzioni mobile.
 </Overview>
 
 <Section
   title="Playground"
-  description="Usa i controlli per modificare i parametri principali del componente e verificare il risultato live."
+  description="Usa i controlli per scegliere la modalità di navigazione, modificare le etichette e confrontare le varianti del componente."
 >
   <Primary />
   <Controls />
 </Section>
 
 <Section
-  title="Varianti"
-  description="MIBreadcrumbs supporta due varianti: extended e compact.
-  Nella variante compact, indipendentemente dal numero di elementi delle breadcrumbs e dalla risoluzione,
-  viene mostrata solo il pulsante 'Indietro'. (Il cui testo è personalizzabile)"
+  title="Navigazione"
+  description="Gli elementi precedenti alla pagina corrente possono essere configurati come link tramite href oppure come azioni tramite onClick."
 >
-  <Story of={MIBreadcrumbsStories.Variants} />
+  <SubSection title="Link">
+    La prop <code>href</code> configura l'elemento come collegamento. Le props pubbliche
+    dell'elemento link espongono anche <code>target</code> e <code>rel</code>.
+
+    <Story of={MIBreadcrumbsStories.LinkNavigation} />
+
+    ```tsx
+    <MIBreadcrumbs aria-label="Percorso di navigazione">
+      <MIBreadcrumbItem label="Dashboard" href="/dashboard" />
+      <MIBreadcrumbItem label="Elenco ricevute" href="/ricevute" />
+      <MIBreadcrumbItem label="Dettaglio ricevuta" current />
+    </MIBreadcrumbs>
+    ```
+
+  </SubSection>
+
+{' '}
+
+  <SubSection title="Azione">
+    La prop <code>onClick</code> permette di delegare la navigazione a una funzione, ad esempio
+    quando l'applicazione usa un sistema di routing client-side. L'elemento viene renderizzato
+    come controllo interattivo di tipo button.
+
+    <Story of={MIBreadcrumbsStories.ActionNavigation} />
+
+    ```tsx
+    <MIBreadcrumbs aria-label="Percorso di navigazione">
+      <MIBreadcrumbItem
+        label="Dashboard"
+        onClick={() => navigate('/dashboard')}
+      />
+      <MIBreadcrumbItem
+        label="Elenco ricevute"
+        onClick={() => navigate('/ricevute')}
+      />
+      <MIBreadcrumbItem label="Dettaglio ricevuta" current />
+    </MIBreadcrumbs>
+    ```
+
+  </SubSection>
+
+{' '}
+
+  <SubSection title="Configurazioni alternative">
+    Le configurazioni <code>href</code>, <code>onClick</code> e <code>current</code> sono
+    alternative tra loro. In base alle props pubbliche, un <code>MIBreadcrumbItem</code> non può
+    rappresentare contemporaneamente un link, un'azione e la pagina corrente.
+  </SubSection>
 </Section>
 
 <Section
-  title="Routing"
-  description="MIBreadcrumbs supporta due modalità di routing: Link e OnClick."
+  title="Varianti"
+  description="MIBreadcrumbs espone le varianti extended e compact, che determinano se mostrare la gerarchia completa oppure il pulsante Indietro."
 >
-  Per sfruttare la navigazione standard basata su URL, è necessario specificare la prop href. 
-  Per sfruttare la navigazione personalizzata, è necessario specificare la prop onClick.
-  Segue un esempio di implementazione che sfrutta la navigazione client side di react-router-dom:
+  <SubSection title="Extended">
+    La variante <code>extended</code> mostra gli elementi ricevuti tramite <code>children</code>.
+    Alle risoluzioni mobile sostituisce automaticamente la gerarchia con il pulsante Indietro.
 
-    <pre>
-    ```js filename="index.js"
-    ...
-    import { MIBreadcrumbs, MIBreadcrumbItem } from 'components/MIBreadcrumbs';
-    import { useNavigate } from 'react-router-dom';
-    ...
-    const navigate = useNavigate();
-    ...
-    return (
-      <MIBreadcrumbs>
-        <MIBreadcrumbItem label="Home" onClick={() => navigate('/')} />
-        <MIBreadcrumbItem label="About" onClick={() => navigate('/about')} />
-        <MIBreadcrumbItem label="Contact" current/>
-      </MIBreadcrumbs>
-    )
-    ...
+    <Story of={MIBreadcrumbsStories.Extended} />
+
+  </SubSection>
+
+{' '}
+
+  <SubSection title="Compact">
+    La variante <code>compact</code> mostra sempre il pulsante Indietro e non renderizza gli
+    elementi ricevuti tramite <code>children</code>.
+
+    <Story of={MIBreadcrumbsStories.Compact} />
+
+  </SubSection>
+
+{' '}
+
+  <SubSection title="Confronto">
+    La story seguente permette di confrontare le due varianti senza modificare manualmente
+    i Controls.
+
+    <Story of={MIBreadcrumbsStories.Variants} />
+
+  </SubSection>
+</Section>
+
+<Section
+  title="Composizione"
+  description="La gerarchia viene costruita tramite una sequenza ordinata di MIBreadcrumbItem."
+>
+  <SubSection title="Ordine degli elementi">
+    L'ordine degli elementi deve rispecchiare la gerarchia di navigazione. Gli elementi
+    precedenti rappresentano destinazioni o azioni disponibili, mentre l'ultimo elemento
+    può identificare la pagina corrente tramite <code>current</code>.
+
+    ```tsx
+    <MIBreadcrumbs aria-label="Percorso di navigazione">
+      <MIBreadcrumbItem label="Dashboard" href="/dashboard" />
+      <MIBreadcrumbItem label="Elenco ricevute" href="/ricevute" />
+      <MIBreadcrumbItem label="Dettaglio ricevuta" current />
+    </MIBreadcrumbs>
     ```
-    </pre>
-    Se entrambe le modalità sono state specificate, prevale onClick.
+
+  </SubSection>
+
+{' '}
+
+  <SubSection title="Navigazione indietro">
+    La prop <code>backButtonAction</code> definisce l'azione eseguita dal pulsante Indietro.
+    Se non viene fornita, il componente usa <code>window.history.back()</code>. La relativa
+    etichetta può essere personalizzata tramite <code>backButtonLabel</code>.
+
+    ```tsx
+    <MIBreadcrumbs
+      variant="compact"
+      backButtonLabel="Elenco ricevute"
+      backButtonAction={() => navigate('/ricevute')}
+      aria-label="Navigazione alla pagina precedente"
+    />
+    ```
+
+  </SubSection>
+</Section>
+
+<Section
+  title="Comportamento responsive"
+  description="La presentazione dipende dalla variante selezionata e dalla larghezza del viewport."
+>
+  <SubSection title="Risoluzioni mobile">
+    Con la variante <code>extended</code>, alle risoluzioni inferiori o uguali al breakpoint
+    <code>sm</code> del tema, la gerarchia viene sostituita dal pulsante Indietro.
+  </SubSection>
+
+{' '}
+
+  <SubSection title="Variante compact">
+    Con <code>variant="compact"</code> il pulsante Indietro viene mostrato a tutte le
+    risoluzioni, indipendentemente dal numero di elementi passati come <code>children</code>.
+  </SubSection>
+</Section>
+
+<Section
+  title="Accessibilità"
+  description="MIBreadcrumbs usa un elemento di navigazione e identifica semanticamente la pagina corrente. L’accessibilità finale dipende da etichette significative e dalla corretta composizione degli elementi."
+>
+  <SubSection title="Props rilevanti">
+    <ul>
+      <li>
+        <strong>aria-label</strong>: descrive la navigazione che contiene le breadcrumb. Il
+        componente usa <code>breadcrumbs</code> come valore predefinito e consente di
+        sovrascriverlo tramite le props del contenitore.
+      </li>
+      <li>
+        <strong>label</strong>: fornisce il testo visibile di ogni elemento e deve descrivere
+        chiaramente la relativa destinazione o pagina.
+      </li>
+      <li>
+        <strong>current</strong>: identifica la pagina attuale. L'elemento corrispondente viene
+        renderizzato con <code>aria-current="page"</code>.
+      </li>
+      <li>
+        <strong>backButtonLabel</strong>: costituisce il testo visibile del pulsante Indietro.
+        Deve descrivere in modo significativo la navigazione eseguita.
+      </li>
+      <li>
+        <strong>target</strong> e <strong>rel</strong>: sono disponibili sugli elementi
+        configurati tramite <code>href</code> e devono essere valorizzati coerentemente con il
+        comportamento del collegamento.
+      </li>
+    </ul>
+  </SubSection>
+
+{' '}
+
+{' '}
+<SubSection title="Pagina corrente">
+  L'elemento con <code>current</code> viene renderizzato come testo non interattivo e riceve
+  automaticamente <code>aria-current="page"</code>. Nella composizione della gerarchia deve
+  rappresentare la pagina attualmente visualizzata.
+</SubSection>
+
+{' '}
+
+{' '}
+<SubSection title="Navigazione da tastiera">
+  Gli elementi configurati tramite <code>href</code> sono collegamenti, mentre quelli configurati
+  tramite <code>onClick</code> vengono renderizzati come pulsanti. Entrambi sono raggiungibili
+  tramite tastiera. L'elemento con <code>current</code> è invece informativo e non interattivo.
+</SubSection>
+
+{' '}
+
+{' '}
+<SubSection title="Pulsante Indietro">
+  Nelle visualizzazioni mobile e nella variante <code>compact</code>, la gerarchia viene sostituita
+  dal pulsante Indietro. Evita una <code>backButtonLabel</code> vuota finché il componente non
+  espone un'etichetta accessibile separata per la configurazione con la sola icona.
+</SubSection>
+
+{' '}
+
+  <SubSection title="Esempio accessibile">
+    ```tsx
+    <MIBreadcrumbs
+      aria-label="Percorso di navigazione"
+      backButtonLabel="Torna all'elenco ricevute"
+      backButtonAction={() => navigate('/ricevute')}
+    >
+      <MIBreadcrumbItem label="Dashboard" href="/dashboard" />
+      <MIBreadcrumbItem label="Elenco ricevute" href="/ricevute" />
+      <MIBreadcrumbItem label="Dettaglio ricevuta" current />
+    </MIBreadcrumbs>
+    ```
+  </SubSection>
 </Section>

--- a/src/docs/MIBreadcrumbs.mdx
+++ b/src/docs/MIBreadcrumbs.mdx
@@ -37,7 +37,6 @@ import * as MIBreadcrumbsStories from '../stories/MIBreadcrumbs.stories.tsx';
   <Story of={MIBreadcrumbsStories.Variants} />
 </Section>
 
-
 <Section
   title="Routing"
   description="MIBreadcrumbs supporta due modalità di routing: Link e OnClick."

--- a/src/docs/MIBreadcrumbs.mdx
+++ b/src/docs/MIBreadcrumbs.mdx
@@ -67,5 +67,5 @@ import * as MIBreadcrumbsStories from '../stories/MIBreadcrumbs.stories.tsx';
     ...
     ```
     </pre>
-    Se entrambe le modalità sono state specificate, prevale onClick (tramite un preventDefault sull'evento click).
+    Se entrambe le modalità sono state specificate, prevale onClick.
 </Section>

--- a/src/stories/MIBreadcrumbs.stories.tsx
+++ b/src/stories/MIBreadcrumbs.stories.tsx
@@ -36,7 +36,8 @@ export const CustomMobileOnly: Story = {};
 CustomMobileOnly.args = {
   variant: 'mobileOnly',
   mobileButtonLabel: 'Esci',
-  mobileButtonIcon: 'Close'
+  mobileButtonIcon: 'Close',
+  mobileButtonAction: () => console.log('Esci')
 }
 
 export const WithIcons: Story = {};

--- a/src/stories/MIBreadcrumbs.stories.tsx
+++ b/src/stories/MIBreadcrumbs.stories.tsx
@@ -1,0 +1,46 @@
+import { MIBreadcrumbs } from '../components/MIBreadcrumbs';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MIBreadcrumbsProps } from '@components/MIBreadcrumbs/types';
+import { Stack } from '@mui/system';
+
+const meta: Meta<MIBreadcrumbsProps> = {
+  title: 'Components/MIBreadcrumbs',
+  component: MIBreadcrumbs,
+  parameters: {
+    layout: 'centered'
+  },
+  render: (args) => (
+    <MIBreadcrumbs {...args} />
+  )
+};
+export default meta;
+
+export type Story = StoryObj<MIBreadcrumbsProps>;
+
+export const Default: Story = {};
+
+Default.args = {
+  breadcrumbs: [{ label: 'Home' }, { label: 'About' }, { label: 'Contact' }],
+}
+
+export const Wizard: Story = {};
+Wizard.args = {
+  variant: 'wizard',
+}
+
+export const WizardWithCustomBackButtonLabel: Story = {};
+WizardWithCustomBackButtonLabel.args = {
+  variant: 'wizard',
+  backButtonLabel: 'About',
+}
+
+export const Variants: Story = {
+  tags: ['!dev'],
+  render: () => (
+    <Stack direction="column" spacing={4} alignItems="center">
+      <MIBreadcrumbs {...Default.args} />
+      <MIBreadcrumbs {...Wizard.args} />
+    </Stack>
+  ),
+};
+

--- a/src/stories/MIBreadcrumbs.stories.tsx
+++ b/src/stories/MIBreadcrumbs.stories.tsx
@@ -20,17 +20,17 @@ export type Story = StoryObj<MIBreadcrumbsProps>;
 export const Default: Story = {};
 
 Default.args = {
-  breadcrumbs: [{ label: 'Home' }, { label: 'About' }, { label: 'Contact' }],
+  elements: [{ label: 'Dashboard' }, { label: 'Elenco Ricevute' }, { label: 'Dettaglio Ricevuta' }],
 }
 
-export const Wizard: Story = {};
-Wizard.args = {
-  variant: 'wizard',
+export const MobileOnly: Story = {};
+MobileOnly.args = {
+  variant: 'mobileOnly',
 }
 
-export const WizardWithCustomBackButtonLabel: Story = {};
-WizardWithCustomBackButtonLabel.args = {
-  variant: 'wizard',
+export const MobileOnlyWithCustomBackButtonLabel: Story = {};
+MobileOnlyWithCustomBackButtonLabel.args = {
+  variant: 'mobileOnly',
   backButtonLabel: 'About',
 }
 
@@ -39,7 +39,7 @@ export const Variants: Story = {
   render: () => (
     <Stack direction="column" spacing={4} alignItems="center">
       <MIBreadcrumbs {...Default.args} />
-      <MIBreadcrumbs {...Wizard.args} />
+      <MIBreadcrumbs {...MobileOnly.args} />
     </Stack>
   ),
 };

--- a/src/stories/MIBreadcrumbs.stories.tsx
+++ b/src/stories/MIBreadcrumbs.stories.tsx
@@ -1,51 +1,250 @@
-import { MIBreadcrumbItem, MIBreadcrumbs } from '../components/MIBreadcrumbs';
+import { Stack, Typography } from '@mui/material';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MIBreadcrumbsProps } from '@components/MIBreadcrumbs/types';
-import { Stack } from '@mui/system';
+import type { ComponentProps } from 'react';
 
-const meta: Meta<MIBreadcrumbsProps> = {
+import { MIBreadcrumbItem, MIBreadcrumbs } from '../components/MIBreadcrumbs';
+
+type MIBreadcrumbsStoryArgs = ComponentProps<typeof MIBreadcrumbs> & {
+  navigationMode: 'link' | 'action';
+  firstItemLabel: string;
+  secondItemLabel: string;
+  currentItemLabel: string;
+};
+
+const meta: Meta<MIBreadcrumbsStoryArgs> = {
   title: 'Components/MIBreadcrumbs',
   component: MIBreadcrumbs,
+  tags: ['!dev'],
   parameters: {
-    layout: 'centered'
+    layout: 'centered',
+    controls: {
+      include: [
+        'variant',
+        'navigationMode',
+        'backButtonLabel',
+        'aria-label',
+        'firstItemLabel',
+        'secondItemLabel',
+        'currentItemLabel',
+      ],
+    },
   },
-  render: (args) => (
-    <MIBreadcrumbs {...args} />
-  )
+  args: {
+    variant: 'extended',
+    navigationMode: 'link',
+    backButtonLabel: 'Indietro',
+    'aria-label': 'Percorso di navigazione',
+    firstItemLabel: 'Dashboard',
+    secondItemLabel: 'Elenco ricevute',
+    currentItemLabel: 'Dettaglio ricevuta',
+  },
+  argTypes: {
+    variant: {
+      options: ['extended', 'compact'],
+      control: { type: 'radio' },
+      description: 'Determina se mostrare la gerarchia completa oppure il solo pulsante Indietro.',
+    },
+    navigationMode: {
+      options: ['link', 'action'],
+      control: { type: 'radio' },
+      description:
+        'Controllo Storybook: configura gli elementi precedenti come link tramite href oppure come azioni tramite onClick.',
+      table: {
+        category: 'Storybook controls',
+      },
+    },
+    backButtonLabel: {
+      control: { type: 'text' },
+      description:
+        'Etichetta del pulsante mostrato nella variante compact e alle risoluzioni mobile.',
+    },
+    'aria-label': {
+      control: { type: 'text' },
+      description: 'Etichetta accessibile dell’elemento di navigazione che contiene le breadcrumb.',
+    },
+    firstItemLabel: {
+      control: { type: 'text' },
+      description: 'Controllo Storybook: etichetta del primo elemento della gerarchia.',
+      table: {
+        category: 'Storybook controls',
+      },
+    },
+    secondItemLabel: {
+      control: { type: 'text' },
+      description: 'Controllo Storybook: etichetta del secondo elemento della gerarchia.',
+      table: {
+        category: 'Storybook controls',
+      },
+    },
+    currentItemLabel: {
+      control: { type: 'text' },
+      description: 'Controllo Storybook: etichetta della pagina corrente.',
+      table: {
+        category: 'Storybook controls',
+      },
+    },
+    children: {
+      control: false,
+      description:
+        'Elenco ordinato di MIBreadcrumbItem che rappresenta la gerarchia di navigazione.',
+    },
+    backButtonAction: {
+      control: false,
+      description: 'Callback eseguita quando viene attivato il pulsante Indietro.',
+    },
+    sx: {
+      control: false,
+    },
+  },
+  render: ({
+    navigationMode,
+    firstItemLabel,
+    secondItemLabel,
+    currentItemLabel,
+    variant,
+    backButtonLabel,
+    'aria-label': ariaLabel,
+  }) => {
+    const items =
+      navigationMode === 'link'
+        ? [
+            <MIBreadcrumbItem key="dashboard" label={firstItemLabel} href="/dashboard" />,
+            <MIBreadcrumbItem key="receipts" label={secondItemLabel} href="/ricevute" />,
+            <MIBreadcrumbItem key="current" label={currentItemLabel} current />,
+          ]
+        : [
+            <MIBreadcrumbItem
+              key="dashboard"
+              label={firstItemLabel}
+              onClick={() => console.info('Navigazione alla dashboard')}
+            />,
+            <MIBreadcrumbItem
+              key="receipts"
+              label={secondItemLabel}
+              onClick={() => console.info('Navigazione all’elenco ricevute')}
+            />,
+            <MIBreadcrumbItem key="current" label={currentItemLabel} current />,
+          ];
+
+    return (
+      <MIBreadcrumbs
+        variant={variant}
+        backButtonLabel={backButtonLabel}
+        backButtonAction={() => console.info('Navigazione indietro')}
+        aria-label={ariaLabel}
+      >
+        {items}
+      </MIBreadcrumbs>
+    );
+  },
 };
+
 export default meta;
 
-export type Story = StoryObj<MIBreadcrumbsProps>;
+type Story = StoryObj<MIBreadcrumbsStoryArgs>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
-Default.args = {
-  children: [
-    <MIBreadcrumbItem key="1" label="Dashboard" href="/"></MIBreadcrumbItem>,
-    <MIBreadcrumbItem key="2" label="Elenco Ricevute" href="/list"></MIBreadcrumbItem>,
-    <MIBreadcrumbItem key="3" label="Dettaglio Ricevuta" current></MIBreadcrumbItem>
-  ],
-}
-
-export const CompactOnly: Story = {};
-CompactOnly.args = {
-  variant: 'compact',
-}
-
-export const CustomCompactOnly: Story = {};
-CustomCompactOnly.args = {
-  variant: 'compact',
-  backButtonLabel: 'Elenco Ricevute',
-  backButtonAction: () => console.log('Esci')
-}
-
-export const Variants: Story = {
-  tags: ['!dev'],
+export const LinkNavigation: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
   render: () => (
-    <Stack direction="column" spacing={4} alignItems="center">
-      <MIBreadcrumbs {...Default.args} />
-      <MIBreadcrumbs {...CompactOnly.args} />
-    </Stack>
+    <MIBreadcrumbs aria-label="Percorso di navigazione">
+      <MIBreadcrumbItem label="Dashboard" href="/dashboard" />
+      <MIBreadcrumbItem label="Elenco ricevute" href="/ricevute" />
+      <MIBreadcrumbItem label="Dettaglio ricevuta" current />
+    </MIBreadcrumbs>
   ),
 };
 
+export const ActionNavigation: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: () => (
+    <MIBreadcrumbs aria-label="Percorso di navigazione">
+      <MIBreadcrumbItem
+        label="Dashboard"
+        onClick={() => console.info('Navigazione alla dashboard')}
+      />
+      <MIBreadcrumbItem
+        label="Elenco ricevute"
+        onClick={() => console.info('Navigazione all’elenco ricevute')}
+      />
+      <MIBreadcrumbItem label="Dettaglio ricevuta" current />
+    </MIBreadcrumbs>
+  ),
+};
+
+export const Extended: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: () => (
+    <MIBreadcrumbs
+      variant="extended"
+      aria-label="Percorso di navigazione"
+      backButtonLabel="Indietro"
+      backButtonAction={() => console.info('Navigazione indietro')}
+    >
+      <MIBreadcrumbItem label="Dashboard" href="/dashboard" />
+      <MIBreadcrumbItem label="Elenco ricevute" href="/ricevute" />
+      <MIBreadcrumbItem label="Dettaglio ricevuta" current />
+    </MIBreadcrumbs>
+  ),
+};
+
+export const Compact: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: () => (
+    <MIBreadcrumbs
+      variant="compact"
+      aria-label="Navigazione alla pagina precedente"
+      backButtonLabel="Elenco ricevute"
+      backButtonAction={() => console.info('Navigazione all’elenco ricevute')}
+    />
+  ),
+};
+
+export const Variants: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: () => (
+    <Stack direction="column" spacing={4} alignItems="flex-start">
+      <Stack spacing={1}>
+        <Typography variant="caption">Extended</Typography>
+
+        <MIBreadcrumbs variant="extended" aria-label="Percorso di navigazione">
+          <MIBreadcrumbItem label="Dashboard" href="/dashboard" />
+          <MIBreadcrumbItem label="Elenco ricevute" href="/ricevute" />
+          <MIBreadcrumbItem label="Dettaglio ricevuta" current />
+        </MIBreadcrumbs>
+      </Stack>
+
+      <Stack spacing={1}>
+        <Typography variant="caption">Compact</Typography>
+
+        <MIBreadcrumbs
+          variant="compact"
+          aria-label="Navigazione alla pagina precedente"
+          backButtonLabel="Elenco ricevute"
+          backButtonAction={() => console.info('Navigazione all’elenco ricevute')}
+        />
+      </Stack>
+    </Stack>
+  ),
+};

--- a/src/stories/MIBreadcrumbs.stories.tsx
+++ b/src/stories/MIBreadcrumbs.stories.tsx
@@ -32,18 +32,19 @@ MobileOnly.args = {
   variant: 'mobileOnly',
 }
 
-export const MobileOnlyWithCustomBackButtonLabel: Story = {};
-MobileOnlyWithCustomBackButtonLabel.args = {
+export const CustomMobileOnly: Story = {};
+CustomMobileOnly.args = {
   variant: 'mobileOnly',
-  mobileButtonLabel: 'About',
+  mobileButtonLabel: 'Esci',
+  mobileButtonIcon: 'Close'
 }
 
 export const WithIcons: Story = {};
 WithIcons.args = {
   elements: [
-    { label: 'Home', icon: 'Home', href: '#' },
-    { label: 'Ricevute', icon: 'Receipt', href: '#' },
-    { label: 'Dettaglio', disabled: true }
+    { label: 'Home', icon: 'Home', onClick: () => console.log('Home') },
+    { label: 'Ricevute', icon: 'Receipt', onClick: () => console.log('Ricevute') },
+    { label: 'Dettaglio', disabled: true, onClick: () => console.log('Dettaglio'), href: '#' }
   ]
 };
 

--- a/src/stories/MIBreadcrumbs.stories.tsx
+++ b/src/stories/MIBreadcrumbs.stories.tsx
@@ -1,4 +1,4 @@
-import { MIBreadcrumbs } from '../components/MIBreadcrumbs';
+import { MIBreadcrumbItem, MIBreadcrumbs } from '../components/MIBreadcrumbs';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { MIBreadcrumbsProps } from '@components/MIBreadcrumbs/types';
 import { Stack } from '@mui/system';
@@ -20,41 +20,31 @@ export type Story = StoryObj<MIBreadcrumbsProps>;
 export const Default: Story = {};
 
 Default.args = {
-  elements: [
-    { label: 'Dashboard' },
-    { label: 'Elenco Ricevute' },
-    { label: 'Dettaglio Ricevuta' }
+  children: [
+    <MIBreadcrumbItem key="1" label="Dashboard" href="/"></MIBreadcrumbItem>,
+    <MIBreadcrumbItem key="2" label="Elenco Ricevute" href="/list"></MIBreadcrumbItem>,
+    <MIBreadcrumbItem key="3" label="Dettaglio Ricevuta" current></MIBreadcrumbItem>
   ],
 }
 
-export const MobileOnly: Story = {};
-MobileOnly.args = {
-  variant: 'mobileOnly',
+export const CompactOnly: Story = {};
+CompactOnly.args = {
+  variant: 'compact',
 }
 
-export const CustomMobileOnly: Story = {};
-CustomMobileOnly.args = {
-  variant: 'mobileOnly',
-  mobileButtonLabel: 'Esci',
-  mobileButtonIcon: 'Close',
-  mobileButtonAction: () => console.log('Esci')
+export const CustomCompactOnly: Story = {};
+CustomCompactOnly.args = {
+  variant: 'compact',
+  backButtonLabel: 'Elenco Ricevute',
+  backButtonAction: () => console.log('Esci')
 }
-
-export const WithIcons: Story = {};
-WithIcons.args = {
-  elements: [
-    { label: 'Home', icon: 'Home', onClick: () => console.log('Home') },
-    { label: 'Ricevute', icon: 'Receipt', onClick: () => console.log('Ricevute') },
-    { label: 'Dettaglio', disabled: true, onClick: () => console.log('Dettaglio'), href: '#' }
-  ]
-};
 
 export const Variants: Story = {
   tags: ['!dev'],
   render: () => (
     <Stack direction="column" spacing={4} alignItems="center">
       <MIBreadcrumbs {...Default.args} />
-      <MIBreadcrumbs {...MobileOnly.args} />
+      <MIBreadcrumbs {...CompactOnly.args} />
     </Stack>
   ),
 };

--- a/src/stories/MIBreadcrumbs.stories.tsx
+++ b/src/stories/MIBreadcrumbs.stories.tsx
@@ -20,7 +20,11 @@ export type Story = StoryObj<MIBreadcrumbsProps>;
 export const Default: Story = {};
 
 Default.args = {
-  elements: [{ label: 'Dashboard' }, { label: 'Elenco Ricevute' }, { label: 'Dettaglio Ricevuta' }],
+  elements: [
+    { label: 'Dashboard' },
+    { label: 'Elenco Ricevute' },
+    { label: 'Dettaglio Ricevuta' }
+  ],
 }
 
 export const MobileOnly: Story = {};
@@ -31,8 +35,17 @@ MobileOnly.args = {
 export const MobileOnlyWithCustomBackButtonLabel: Story = {};
 MobileOnlyWithCustomBackButtonLabel.args = {
   variant: 'mobileOnly',
-  backButtonLabel: 'About',
+  mobileButtonLabel: 'About',
 }
+
+export const WithIcons: Story = {};
+WithIcons.args = {
+  elements: [
+    { label: 'Home', icon: 'Home', href: '#' },
+    { label: 'Ricevute', icon: 'Receipt', href: '#' },
+    { label: 'Dettaglio', disabled: true }
+  ]
+};
 
 export const Variants: Story = {
   tags: ['!dev'],


### PR DESCRIPTION
## Short description
Create a custom `MIBreadcrumbs` component based on MUI `Breadcrumbs`. 

### Preview
<img width="409" height="73" alt="image" src="https://github.com/user-attachments/assets/588bed52-50d0-44ef-947d-d857493e248e" />
<br>
<img width="377" height="68" alt="image" src="https://github.com/user-attachments/assets/d88a861f-90cd-484e-8462-cf81dca77c8f" />


## List of changes proposed in this pull request
- Create new `MIBreadcrumbs` component
- Add `MIBreadcrumbs` documentation and stories

## How to test
- Run Storybook 
- Check that the MIBreadcrumbs component matches the [Figma design](https://www.figma.com/design/pvhsJpPGQbEwNLiyP7BOIw/MUI-Italia-Next---Design-System?node-id=1-21)