### PR TITLE
fix(M20DS-125): fix MIAlert crash under Nextjs Pages Router webpack bundling

### DIFF
--- a/.babelrc.mjs
+++ b/.babelrc.mjs
@@ -52,21 +52,13 @@ export default function getBabelConfig(api) {
       'src/**/*.stories.ts',
       'src/**/*.stories.tsx'
     );
-    config.plugins.push(
-      [
-        'babel-plugin-module-resolver',
-        {
-          root: ['./'],
-          alias: resolveAliases(),
-        },
-      ],
-      [
-        'babel-plugin-transform-rewrite-imports',
-        {
-          replaceExtensions: { '^@mui/icons-material(.+?)': `@mui/icons-material/esm$1` },
-        },
-      ]
-    );
+    config.plugins.push([
+      'babel-plugin-module-resolver',
+      {
+        root: ['./'],
+        alias: resolveAliases(),
+      },
+    ]);
     config.presets.push(
       ['@babel/preset-env', { modules: false }], // modules false preserve es modules
       [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@typescript-eslint/eslint-plugin": "^5.47.1",
     "@typescript-eslint/parser": "^5.39.0",
     "babel-plugin-module-resolver": "^5.0.2",
-    "babel-plugin-transform-rewrite-imports": "^1.5.4",
     "babel-preset-minify": "^0.5.2",
     "chromatic": "^6.17.2",
     "date-fns": "^2.29.3",

--- a/src/components/MIAlert/MIAlert.tsx
+++ b/src/components/MIAlert/MIAlert.tsx
@@ -1,8 +1,15 @@
 'use client';
 
 import { ButtonNaked } from '@components/ButtonNaked';
-import { AlertTitle as MUIAlertTitle, Stack, styled, useMediaQuery, useTheme } from '@mui/material';
-import MUIAlert, { AlertProps as MUIAlertProps } from '@mui/material/Alert';
+import {
+  Alert as MUIAlert,
+  AlertProps as MUIAlertProps,
+  AlertTitle as MUIAlertTitle,
+  Stack,
+  styled,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import { ElementType, HTMLAttributeAnchorTarget } from 'react';
 import { getColor, getIcon } from './utils';
 import { MarginSxProps } from '@types';

--- a/src/components/MIAlert/utils.tsx
+++ b/src/components/MIAlert/utils.tsx
@@ -1,7 +1,9 @@
-import InfoRoundedIcon from '@mui/icons-material/InfoRounded';
-import ReportRoundedIcon from '@mui/icons-material/ReportRounded';
-import WarningRoundedIcon from '@mui/icons-material/WarningRounded';
-import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
+import {
+  InfoRounded as InfoRoundedIcon,
+  ReportRounded as ReportRoundedIcon,
+  WarningRounded as WarningRoundedIcon,
+  CheckCircleRounded as CheckCircleRoundedIcon,
+} from '@mui/icons-material';
 import type { Theme } from '@mui/material/styles';
 import type { AllowedAlertSeverity } from './MIAlert';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,18 +5,6 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@-xun/debug@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@-xun/debug@npm:2.0.2"
-  dependencies:
-    "@types/debug": ^4.1.12
-    debug: ^4.4.1
-    supports-color: ^8.1.1
-    type-fest: ^4.41.0
-  checksum: 8c05416f3db1527466d10b04ba0f1e91e4ffe9d80acabb6780516f271297e82234cf0f8dd1c924f2ce8d7007e813931211750ea156acf84e3795f5e24b2e20a6
-  languageName: node
-  linkType: hard
-
 "@adobe/css-tools@npm:^4.4.0":
   version: 4.4.4
   resolution: "@adobe/css-tools@npm:4.4.4"
@@ -1237,7 +1225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.27.2, @babel/template@npm:^7.28.6":
+"@babel/template@npm:^7.28.6":
   version: 7.28.6
   resolution: "@babel/template@npm:7.28.6"
   dependencies:
@@ -2165,7 +2153,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.47.1
     "@typescript-eslint/parser": ^5.39.0
     babel-plugin-module-resolver: ^5.0.2
-    babel-plugin-transform-rewrite-imports: ^1.5.4
     babel-preset-minify: ^0.5.2
     chromatic: ^6.17.2
     clsx: ^1.2.1
@@ -2634,15 +2621,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/debug@npm:^4.1.12":
-  version: 4.1.13
-  resolution: "@types/debug@npm:4.1.13"
-  dependencies:
-    "@types/ms": "*"
-  checksum: 5091d4ebda85236e6f4a6ecea552860e521e11d1d388d3f6255b40726f5a4a7cf1baa0d09f60853838e4cac6c12a13b14114d5f422ccecaee4d1d07dab349900
-  languageName: node
-  linkType: hard
-
 "@types/deep-eql@npm:*":
   version: 4.0.2
   resolution: "@types/deep-eql@npm:4.0.2"
@@ -2682,13 +2660,6 @@ __metadata:
   version: 2.0.13
   resolution: "@types/mdx@npm:2.0.13"
   checksum: 195137b548e75a85f0558bb1ca5088aff1c01ae0fc64454da06085b7513a043356d0bb51ed559d3cbc7ad724ccd8cef2a7d07d014b89a47a74dff8875ceb3b15
-  languageName: node
-  linkType: hard
-
-"@types/ms@npm:*":
-  version: 2.1.0
-  resolution: "@types/ms@npm:2.1.0"
-  checksum: 532d2ebb91937ccc4a89389715e5b47d4c66e708d15942fe6cc25add6dc37b2be058230a327dd50f43f89b8b6d5d52b74685a9e8f70516edfc9bdd6be910eff4
   languageName: node
   linkType: hard
 
@@ -3537,20 +3508,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-transform-rewrite-imports@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "babel-plugin-transform-rewrite-imports@npm:1.5.4"
-  dependencies:
-    "@babel/template": ^7.27.2
-    "@babel/types": ^7.28.2
-    core-js: ^3.45.1
-    rejoinder: ^2.0.3
-  peerDependencies:
-    "@babel/core": ">=7.11.6"
-  checksum: 454845820c21b12c54f70e66cc98df1fc91bff7da4bab0a95ffec2a5f0efe7b4c2d5f85b6b71f1bdfa996ca6964c42aa97f08aac4543ce7884993dc643975697
-  languageName: node
-  linkType: hard
-
 "babel-plugin-transform-simplify-comparison-operators@npm:^6.9.4":
   version: 6.9.4
   resolution: "babel-plugin-transform-simplify-comparison-operators@npm:6.9.4"
@@ -3781,13 +3738,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.6.0":
-  version: 5.6.2
-  resolution: "chalk@npm:5.6.2"
-  checksum: 4ee2d47a626d79ca27cb5299ecdcce840ef5755e287412536522344db0fc51ca0f6d6433202332c29e2288c6a90a2b31f3bd626bc8c14743b6b6ee28abd3b796
-  languageName: node
-  linkType: hard
-
 "check-error@npm:^2.1.1":
   version: 2.1.3
   resolution: "check-error@npm:2.1.3"
@@ -3913,13 +3863,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.45.1":
-  version: 3.49.0
-  resolution: "core-js@npm:3.49.0"
-  checksum: 0e2c7ce0d6639ac6b0c040c6e82d415e84f94a542fb6523388d204a1c5c2e503870aa64de180115d56a7bc7c780e43b5eab4b925a6f821a9d27f4b92d191713d
-  languageName: node
-  linkType: hard
-
 "cosmiconfig@npm:^7.0.0":
   version: 7.1.0
   resolution: "cosmiconfig@npm:7.1.0"
@@ -4000,7 +3943,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.1, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -4718,13 +4661,6 @@ __metadata:
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
-  languageName: node
-  linkType: hard
-
-"exit-hook@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "exit-hook@npm:4.0.0"
-  checksum: 5aa8b4e45fa943e7e174c25329750a0ffefb593ccc2eafd5d67e1d734b114c93cb36b5714548fb1c2a1dd90f3e9cdc606b5e788f428f780708774da444021fdc
   languageName: node
   linkType: hard
 
@@ -6710,18 +6646,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rejoinder@npm:^2.0.3":
-  version: 2.1.0
-  resolution: "rejoinder@npm:2.1.0"
-  dependencies:
-    "@-xun/debug": ^2.0.2
-    chalk: ^5.6.0
-    core-js: ^3.45.1
-    exit-hook: ^4.0.0
-  checksum: 44d86725cfee9d7f629f1f7e05635d9e1b57bcae35320d22beb31fc80017fad5f1a5a44af4c42361aeaec3303e3696916e6fa58b79222ba15278819f38c7d160
-  languageName: node
-  linkType: hard
-
 "reselect@npm:^4.1.7":
   version: 4.1.8
   resolution: "reselect@npm:4.1.8"
@@ -7363,15 +7287,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^8.1.1":
-  version: 8.1.1
-  resolution: "supports-color@npm:8.1.1"
-  dependencies:
-    has-flag: ^4.0.0
-  checksum: c052193a7e43c6cdc741eb7f378df605636e01ad434badf7324f17fb60c69a880d8d8fcdcb562cf94c2350e57b937d7425ab5b8326c67c2adc48f7c87c1db406
-  languageName: node
-  linkType: hard
-
 "supports-preserve-symlinks-flag@npm:^1.0.0":
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
@@ -7547,13 +7462,6 @@ __metadata:
   version: 0.20.2
   resolution: "type-fest@npm:0.20.2"
   checksum: 4fb3272df21ad1c552486f8a2f8e115c09a521ad7a8db3d56d53718d0c907b62c6e9141ba5f584af3f6830d0872c521357e512381f24f7c44acae583ad517d73
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^4.41.0":
-  version: 4.41.0
-  resolution: "type-fest@npm:4.41.0"
-  checksum: 7055c0e3eb188425d07403f1d5dc175ca4c4f093556f26871fe22041bc93d137d54bef5851afa320638ca1379106c594f5aa153caa654ac1a7f22c71588a4e80
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Short description
MIAlert crashes under Nextjs Pages Router webpack bundling

### Preview

## List of changes proposed in this pull request
- Remove the babel-plugin-transform-rewrite-imports config from .babelrc.mjs 
- Fix import syntax of the Alert component and Icons from MUI 

## Product

## How to test
