### PR TITLE
fix(M20DS-126): add missing props to MIButton and fix outlined style

### DIFF
--- a/src/components/MIButton/MIButton.tsx
+++ b/src/components/MIButton/MIButton.tsx
@@ -1,15 +1,16 @@
 import Button, { ButtonProps } from '@mui/material/Button';
 import { SxProps, Theme } from '@mui/material/styles';
-import React from 'react';
+import { FC } from 'react';
 import MIButtonLoader from './MIButtonLoader';
 import { getColorSx } from './styles';
 import { MIButtonLoaderType, MIButtonProps } from './types';
 
-const MIButton: React.FC<MIButtonProps> = ({
+const MIButton: FC<MIButtonProps> = ({
   color = 'primary',
   variant = 'contained',
   loaderType,
   isLoading,
+  fullWidth,
   loadingAriaLabel,
   children,
   sx,
@@ -33,7 +34,7 @@ const MIButton: React.FC<MIButtonProps> = ({
 
   const extraSx =
     isLoading && loaderType !== MIButtonLoaderType.SKELETON
-      ? { minWidth: props.fullWidth ? '100%' : '72px' }
+      ? { minWidth: fullWidth ? '100%' : '72px' }
       : undefined;
 
   return (
@@ -52,7 +53,7 @@ const MIButton: React.FC<MIButtonProps> = ({
           variant={variant}
           loaderType={loaderType}
           loadingAriaLabel={loadingAriaLabel}
-          fullWidth={props.fullWidth}
+          fullWidth={fullWidth}
         />
       ) : (
         children

--- a/src/components/MIButton/MIButton.tsx
+++ b/src/components/MIButton/MIButton.tsx
@@ -45,6 +45,9 @@ const MIButton: FC<MIButtonProps> = ({
       aria-busy={isLoading || undefined}
       disableRipple
       disableTouchRipple
+      fullWidth={fullWidth}
+      startIcon={isLoading ? null : props.startIcon}
+      endIcon={isLoading ? null : props.endIcon}
       sx={mergeSx(extraSx)}
     >
       {isLoading ? (

--- a/src/components/MIButton/styles.ts
+++ b/src/components/MIButton/styles.ts
@@ -40,7 +40,7 @@ const containedStyles: Record<MIButtonColor, ButtonSx> = {
 
 const outlinedStyles: Record<MIButtonColor, ButtonSx> = {
   primary: {
-    backgroundColor: colors.neutral.white,
+    backgroundColor: 'transparent',
     color: colors.blue[500],
     borderColor: colors.blue[500],
     '&:hover': {
@@ -50,7 +50,7 @@ const outlinedStyles: Record<MIButtonColor, ButtonSx> = {
     },
   },
   error: {
-    backgroundColor: colors.neutral.white,
+    backgroundColor: 'transparent',
     color: colors.error[500],
     borderColor: colors.error[500],
     '&:hover': {
@@ -60,7 +60,7 @@ const outlinedStyles: Record<MIButtonColor, ButtonSx> = {
     },
   },
   contrasted: {
-    backgroundColor: colors.blue[500],
+    backgroundColor: 'transparent',
     color: colors.neutral.white,
     borderColor: colors.neutral.white,
     '&:hover': {

--- a/src/components/MIButton/types.ts
+++ b/src/components/MIButton/types.ts
@@ -1,10 +1,7 @@
 import { ButtonProps } from '@mui/material/Button';
-import { MarginSxProps } from '@types';
+import { SxProps } from '@mui/system';
 
-type PickedButtonProps = Pick<
-  ButtonProps,
-  'fullWidth' | 'endIcon' | 'startIcon' | 'size' | 'children' | 'onClick'
->;
+type PickedButtonProps = Pick<ButtonProps, 'fullWidth' | 'endIcon' | 'startIcon' | 'size'>;
 
 export enum MIButtonLoaderType {
   SKELETON = 'skeleton',
@@ -20,12 +17,12 @@ export type MIButtonColor = 'primary' | 'error' | 'contrasted';
  */
 export type MIButtonVariant = 'contained' | 'outlined' | 'text';
 
-interface MIButtonBaseProps extends PickedButtonProps {
+interface MIButtonBaseProps extends PickedButtonProps, React.HTMLAttributes<HTMLButtonElement> {
   color?: MIButtonColor;
   isLoading?: boolean;
   loaderType?: MIButtonLoaderType;
   loadingAriaLabel?: string;
-  sx?: MarginSxProps;
+  sx?: SxProps;
 }
 
 interface MITextButtonProps extends MIButtonBaseProps {

--- a/src/components/MIButton/types.ts
+++ b/src/components/MIButton/types.ts
@@ -1,7 +1,6 @@
 import { ButtonProps } from '@mui/material/Button';
-import { SxProps } from '@mui/system';
 
-type PickedButtonProps = Pick<ButtonProps, 'fullWidth' | 'endIcon' | 'startIcon' | 'size'>;
+type PickedButtonProps = Pick<ButtonProps, 'fullWidth' | 'endIcon' | 'startIcon' | 'size' | 'sx'>;
 
 export enum MIButtonLoaderType {
   SKELETON = 'skeleton',
@@ -22,7 +21,6 @@ interface MIButtonBaseProps extends PickedButtonProps, React.HTMLAttributes<HTML
   isLoading?: boolean;
   loaderType?: MIButtonLoaderType;
   loadingAriaLabel?: string;
-  sx?: SxProps;
 }
 
 interface MITextButtonProps extends MIButtonBaseProps {

--- a/src/stories/MIButton.stories.tsx
+++ b/src/stories/MIButton.stories.tsx
@@ -28,6 +28,7 @@ const getIcon = (iconPosition: MIButtonStoryArgs['iconPosition']) => {
 const meta: Meta<MIButtonStoryArgs> = {
   title: 'Components/MIButton',
   component: MIButton,
+  tags: ['!dev'],
   parameters: {
     layout: 'centered',
     controls: {


### PR DESCRIPTION
## Short description
Add missing props to MIButton: `type`, `id` and generic `sx`. Also fixed the style of outlined button.

## List of changes proposed in this pull request
- Add missing props
- Fix style

## Product
SEND

## How to test
- Check outlined style of MIButton