### PR TITLE
fix(M20DS-128): add export in index.ts for MIStepper component 

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -43,3 +43,4 @@ export * from './MITimeline';
 export * from './MISnackbar';
 export * from './MIPaper';
 export * from './MIBoxedModule';
+export * from './MIStepper';


### PR DESCRIPTION
## Short description
This pull request adds a new export to the main components index file, making the `MIStepper` component available for import.