### PR TITLE
chore(M20DS-126): fix MiButton props in order to accept type

### DIFF
--- a/src/components/MIButton/types.ts
+++ b/src/components/MIButton/types.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ButtonProps } from '@mui/material/Button';
 
 type PickedButtonProps = Pick<ButtonProps, 'fullWidth' | 'endIcon' | 'startIcon' | 'size' | 'sx'>;
@@ -16,7 +17,9 @@ export type MIButtonColor = 'primary' | 'error' | 'contrasted';
  */
 export type MIButtonVariant = 'contained' | 'outlined' | 'text';
 
-interface MIButtonBaseProps extends PickedButtonProps, React.HTMLAttributes<HTMLButtonElement> {
+interface MIButtonBaseProps
+  extends PickedButtonProps,
+    React.ButtonHTMLAttributes<HTMLButtonElement> {
   color?: MIButtonColor;
   isLoading?: boolean;
   loaderType?: MIButtonLoaderType;


### PR DESCRIPTION
## Short description
Fix MiButton props definition in order to accept `type`

## List of changes proposed in this pull request
- Fix MIButton props
