### PR TITLE
feat(M20DS-55): implement MISingleFileInput component 

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -18,6 +18,10 @@ const backgrounds = {
     name: 'default',
     value: theme.colors.blue[100],
   },
+  white: {
+    name: 'white',
+    value: theme.colors.neutral.white,
+  },
 } as const;
 
 type BackgroundKey = keyof typeof backgrounds;

--- a/src/components/MISingleFileInput/MISingleFileInput.mdx
+++ b/src/components/MISingleFileInput/MISingleFileInput.mdx
@@ -1,0 +1,101 @@
+import { Meta, Title, Canvas, Controls } from '@storybook/addon-docs/blocks';
+import * as MISingleFileInputStories from './MISingleFileInput.stories';
+
+<Meta of={MISingleFileInputStories} />
+
+<Title />
+
+Il componente **MISingleFileInput** gestisce il caricamento di un singolo file
+con interazione drag and drop o selezione da file picker.
+
+Fornisce stati visivi dedicati per caricamento, errore, file selezionato e file
+rifiutato, mantenendo coerenza con il Design System su tipografia, colori e
+spaziature.
+
+**Link utili**
+
+- 🎨 [Figma](https://www.figma.com/design/pvhsJpPGQbEwNLiyP7BOIw/MUI-Italia-Next---Design-System?timeline=keyframe&node-id=813-5421&t=oaB7w1sBtzAo91ie-0)
+- 💻 [GitHub](https://github.com/pagopa/mui-italia/blob/develop/src/components/MISingleFileInput/MISingleFileInput.tsx)
+
+## Playground
+
+<Canvas of={MISingleFileInputStories.Default} />
+
+<Controls of={MISingleFileInputStories.Default} />
+
+## Stati
+
+Il componente espone diversi stati operativi:
+
+- **Idle**: area di upload pronta alla selezione del file.
+- **Drag over**: feedback visivo durante trascinamento file nell'area.
+- **Loading**: caricamento in corso con progress bar indeterminata.
+- **Selected**: file caricato con nome, peso e data ultima modifica.
+- **Error**: stato di errore applicativo tramite prop `error`.
+- **Rejected**: stato di file rifiutato per tipo non ammesso.
+
+### Default
+
+<Canvas of={MISingleFileInputStories.Default} />
+
+### Loading
+
+<Canvas of={MISingleFileInputStories.Loading} />
+
+### Error
+
+<Canvas of={MISingleFileInputStories.Error} />
+
+### Failed
+
+<Canvas of={MISingleFileInputStories.Failed} />
+
+## Visualizzazione file selezionato
+
+Quando `value` contiene un file valido, il componente mostra:
+
+- nome file (con troncamento automatico se troppo lungo);
+- dimensione in KB;
+- data e ora dell'ultima modifica, se disponibile;
+- azione di rimozione, se `onFileRemoved` e valorizzata.
+
+### Con file
+
+<Canvas of={MISingleFileInputStories.WithFile} />
+
+### Nome file lungo
+
+<Canvas of={MISingleFileInputStories.WithTruncatedFileName} />
+
+```tsx
+<MISingleFileInput
+  value={file}
+  label="Documento"
+  accept={['application/pdf']}
+  onFileSelected={handleFileSelected}
+  onFileRemoved={handleFileRemoved}
+  dropzoneLabel="Trascina qui il documento firmato"
+  dropzoneButton="carica il file"
+  dropzoneSupportText="Formato PDF, dimensione massima 5MB"
+  helperText="Campo obbligatorio"
+  onFileRemoveAriaLabel="Rimuovi il documento selezionato"
+/>
+```
+
+## Comportamento
+
+- **Componente controllato.** Il file visualizzato e gestito dal parent tramite `value`.
+- **Selezione file.** `onFileSelected` riceve il file selezionato o droppato.
+- **Rimozione file.** Se `onFileRemoved` e fornita, il componente mostra il controllo di rimozione.
+- **Validazione formato.** La prop `accept` filtra i MIME type ammessi e abilita lo stato `rejected` su mismatch.
+- **Stato rifiutato custom.** `rejected` e `rejectedLabel` possono forzare la visualizzazione di un errore di upload.
+- **Helper text.** `helperText` e mostrato sotto il container e usa una resa visuale di errore.
+
+## Accessibilità
+
+Per un'esperienza accessibile:
+
+- usa testi chiari in `dropzoneLabel`, `dropzoneSupportText` e `helperText`;
+- valorizza `onFileRemoveAriaLabel` con una descrizione esplicita dell'azione;
+- personalizza `loadingLabel` e `cancelButtonLabel` per descrivere correttamente lo stato;
+- evita etichette ambigue su `dropzoneButton` e `retryButtonLabel`.

--- a/src/components/MISingleFileInput/MISingleFileInput.stories.tsx
+++ b/src/components/MISingleFileInput/MISingleFileInput.stories.tsx
@@ -1,0 +1,119 @@
+import { StoryFn, Meta } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { breakpointsChromaticValues } from '@theme';
+import MISingleFileInput from './MISingleFileInput';
+
+const componentMaxWidth = 900;
+
+export default {
+  title: 'Components/MISingleFileInput',
+  component: MISingleFileInput,
+  parameters: {
+    chromatic: {
+      viewports: breakpointsChromaticValues.filter((resolution) => resolution <= componentMaxWidth),
+    },
+    backgroundKey: 'white',
+  },
+} as Meta<typeof MISingleFileInput>;
+
+export const Default: StoryFn<typeof MISingleFileInput> = () => {
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleSelect = (file: File) => {
+    setFile(file);
+  };
+
+  const handleRemove = () => {
+    setFile(null);
+  };
+
+  return (
+    <MISingleFileInput
+      label="Document (required)"
+      value={file}
+      accept={['image/png']}
+      onFileSelected={handleSelect}
+      onFileRemoved={handleRemove}
+      dropzoneLabel="Trascina qui l’Accordo di Adesione firmato"
+      dropzoneSupportText="Dimensione massima 300 x 300px Formato .jpg o .png"
+      dropzoneButton="carica il file"
+      rejectedLabel="Caricamento fallito"
+      helperText="*Campo obbligatorio"
+    />
+  );
+};
+
+export const Loading: StoryFn<typeof MISingleFileInput> = () => (
+  <MISingleFileInput
+    label="Document (required)"
+    value={null}
+    onFileSelected={() => {}}
+    onFileRemoved={() => {}}
+    dropzoneLabel="Trascina qui l’Accordo di Adesione firmato"
+    dropzoneSupportText="Dimensione massima 300 x 300px Formato .jpg o .png"
+    dropzoneButton="carica il file"
+    loading={true}
+    helperText="*Campo obbligatorio"
+  />
+);
+
+export const Error: StoryFn<typeof MISingleFileInput> = () => (
+  <MISingleFileInput
+    label="Document (required)"
+    value={null}
+    error
+    onFileSelected={() => {}}
+    onFileRemoved={() => {}}
+    dropzoneLabel="Trascina qui l’Accordo di Adesione firmato"
+    dropzoneSupportText="Dimensione massima 300 x 300px Formato .jpg o .png"
+    dropzoneButton="carica il file"
+    helperText="*Campo obbligatorio"
+  />
+);
+
+export const WithFile: StoryFn<typeof MISingleFileInput> = () => (
+  <MISingleFileInput
+    label="Document (required)"
+    value={
+      new File(['demo'], 'filename.csv', {
+        lastModified: new Date('2026-10-06T14:17:00').getTime(),
+      })
+    }
+    onFileSelected={() => {}}
+    onFileRemoved={() => {}}
+    dropzoneLabel="Trascina qui l’Accordo di Adesione firmato"
+    dropzoneSupportText="Dimensione massima 300 x 300px Formato .jpg o .png"
+    dropzoneButton="carica il file"
+    helperText="*Campo obbligatorio"
+  />
+);
+
+export const WithTruncatedFileName: StoryFn<typeof MISingleFileInput> = () => (
+  <MISingleFileInput
+    label="Document (required)"
+    value={new File([], 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.docx')}
+    onFileSelected={() => {}}
+    onFileRemoved={() => {}}
+    dropzoneLabel="Trascina qui l’Accordo di Adesione firmato"
+    dropzoneSupportText="Dimensione massima 300 x 300px Formato .jpg o .png"
+    dropzoneButton="carica il file"
+    helperText="*Campo obbligatorio"
+  />
+);
+
+export const Failed: StoryFn<typeof MISingleFileInput> = () => (
+  <MISingleFileInput
+    label="Document (required)"
+    value={null}
+    rejected
+    onFileSelected={() => {}}
+    onFileRemoved={() => {}}
+    dropzoneLabel="Trascina qui l’Accordo di Adesione firmato"
+    dropzoneSupportText="Dimensione massima 300 x 300px Formato .jpg o .png"
+    dropzoneButton="carica il file"
+    rejectedLabel="Caricamento fallito"
+    retryButtonLabel="Riprova"
+    helperText="*Campo obbligatorio"
+  />
+);

--- a/src/components/MISingleFileInput/MISingleFileInput.tsx
+++ b/src/components/MISingleFileInput/MISingleFileInput.tsx
@@ -91,6 +91,8 @@ export type MISingleFileInputProps = {
 
   /** Helper text shown below the container. */
   helperText?: string;
+
+  onFileRemoveAriaLabel?: string;
 };
 
 const formatFileSize = (size: number) => `${Math.max(0, Math.round(size / 1024))} KB`;
@@ -114,7 +116,6 @@ export const MISingleFileInput = ({
   required = false,
   accept,
   loading,
-  vertical = false,
 
   onFileSelected,
   onFileRemoved,
@@ -128,10 +129,11 @@ export const MISingleFileInput = ({
   rejected = false,
   retryButtonLabel = 'Riprova',
   helperText,
+  onFileRemoveAriaLabel = 'Rimuovi file',
 }: MISingleFileInputProps): JSX.Element => {
   const muiTheme = useTheme();
   const isMobileViewport = useMediaQuery(muiTheme.breakpoints.down('md'));
-  const isVerticalLayout = vertical || isMobileViewport;
+  const isVerticalLayout = isMobileViewport;
 
   const uploadInputRef = useRef<HTMLInputElement>(null);
 
@@ -228,17 +230,6 @@ export const MISingleFileInput = ({
     status === UploadStatus.REJECTED ||
     status === UploadStatus.ERROR;
 
-  const minHeight =
-    status === UploadStatus.SELECTED
-      ? isVerticalLayout
-        ? 118
-        : 94
-      : isVerticalLayout
-      ? 236
-      : status === UploadStatus.DRAG_OVER
-      ? 92
-      : 96;
-
   return (
     <FormControl sx={{ width: '100%' }}>
       <FormLabel error={!!error || hasRequiredError} sx={{ fontWeight: 600, mb: 1 }} htmlFor={id}>
@@ -248,7 +239,6 @@ export const MISingleFileInput = ({
       <Box
         sx={{
           position: 'relative',
-          minHeight,
           borderRadius: '10px',
           display: 'flex',
           justifyContent: 'center',
@@ -264,8 +254,7 @@ export const MISingleFileInput = ({
               border: 'none',
               flex: 1,
               width: '100%',
-              px: 3,
-              py: isVerticalLayout ? 3 : 0,
+              p: 3,
             }}
             onDragOver={handleDragOver}
             onDrop={handleDrop}
@@ -488,7 +477,10 @@ export const MISingleFileInput = ({
             </Box>
             {onFileRemoved && (
               <IconButton onClick={handleRemoveFile} sx={{ p: 0, alignSelf: 'flex-start' }}>
-                <CloseIcon sx={{ color: theme.colors.neutral.black }} />
+                <CloseIcon
+                  sx={{ color: theme.colors.neutral.black }}
+                  aria-label={onFileRemoveAriaLabel}
+                />
               </IconButton>
             )}
           </Box>
@@ -501,7 +493,7 @@ export const MISingleFileInput = ({
           sx={{
             display: 'flex',
             alignItems: 'center',
-            mt: 1,
+            mt: 0.5,
             mx: 3,
             columnGap: 0.5,
           }}

--- a/src/components/MISingleFileInput/MISingleFileInput.tsx
+++ b/src/components/MISingleFileInput/MISingleFileInput.tsx
@@ -92,7 +92,11 @@ export type MISingleFileInputProps = {
   /** Helper text shown below the container. */
   helperText?: string;
 
+  /** Aria label for the remove file button. */
   onFileRemoveAriaLabel?: string;
+
+  /** Label for the cancel button in loading state. */
+  cancelButtonLabel?: string;
 };
 
 const formatFileSize = (size: number) => `${Math.max(0, Math.round(size / 1024))} KB`;
@@ -130,6 +134,7 @@ export const MISingleFileInput = ({
   retryButtonLabel = 'Riprova',
   helperText,
   onFileRemoveAriaLabel = 'Rimuovi file',
+  cancelButtonLabel = 'Annulla',
 }: MISingleFileInputProps): JSX.Element => {
   const muiTheme = useTheme();
   const isMobileViewport = useMediaQuery(muiTheme.breakpoints.down('md'));
@@ -157,6 +162,14 @@ export const MISingleFileInput = ({
     status === UploadStatus.REJECTED ? rejectedLabel ?? dropzoneLabel : dropzoneLabel;
   const showDropzoneActionButton = status !== UploadStatus.DRAG_OVER;
   const dropzoneButtonLabel = status === UploadStatus.REJECTED ? retryButtonLabel : dropzoneButton;
+  const dropzonePrimaryLabelId = `${id}-dropzone-primary-label`;
+  const dropzoneSupportTextId = `${id}-dropzone-support-text`;
+
+  const dropzoneAriaLabel = [dropzoneButtonLabel, dropzonePrimaryLabel, dropzoneSupportText]
+    .filter(Boolean)
+    .join('. ');
+  const loadingAriaLabel = [loadingLabel, cancelButtonLabel].filter(Boolean).join('. ');
+  const removeFileAriaLabel = [onFileRemoveAriaLabel, value?.name].filter(Boolean).join('. ');
 
   const chooseFileHandler = () => {
     setIsFileRejected(false);
@@ -260,8 +273,7 @@ export const MISingleFileInput = ({
             onDrop={handleDrop}
             onDragEnter={handleDragEnter}
             onDragLeave={handleDragLeave}
-            component="button"
-            type="button"
+            component="div"
             onClick={chooseFileHandler}
             data-testid="loadFromPc"
           >
@@ -300,6 +312,7 @@ export const MISingleFileInput = ({
                   }}
                 >
                   <Typography
+                    id={dropzonePrimaryLabelId}
                     display="inline"
                     variant="body2"
                     sx={{
@@ -313,6 +326,7 @@ export const MISingleFileInput = ({
                   </Typography>
                   {dropzoneSupportText && (
                     <Typography
+                      id={dropzoneSupportTextId}
                       display="inline"
                       variant="body2"
                       sx={{
@@ -335,21 +349,15 @@ export const MISingleFileInput = ({
                   variant="contained"
                   color={isDropzoneErrorLike ? 'error' : 'primary'}
                   sx={{ whiteSpace: 'nowrap' }}
+                  aria-label={dropzoneAriaLabel}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    chooseFileHandler();
+                  }}
                 >
                   {dropzoneButtonLabel}
                 </MIButton>
               )}
-
-              <Input
-                inputProps={{ accept: accept?.join(',') }}
-                type="file"
-                id={id}
-                sx={{ display: 'none' }}
-                required={required}
-                inputRef={uploadInputRef}
-                onChange={handleSelectFile}
-                data-testid="fileInput"
-              />
             </Stack>
           </Box>
         )}
@@ -402,6 +410,7 @@ export const MISingleFileInput = ({
               {/* Cancel Button */}
               <MIButton
                 variant="outlined"
+                aria-label={loadingAriaLabel}
                 onClick={handleRemoveFile}
                 sx={{
                   whiteSpace: 'nowrap',
@@ -410,7 +419,7 @@ export const MISingleFileInput = ({
                   textTransform: 'none',
                 }}
               >
-                Annulla
+                {cancelButtonLabel}
               </MIButton>
             </Stack>
           </Box>
@@ -476,16 +485,28 @@ export const MISingleFileInput = ({
               </Stack>
             </Box>
             {onFileRemoved && (
-              <IconButton onClick={handleRemoveFile} sx={{ p: 0, alignSelf: 'flex-start' }}>
-                <CloseIcon
-                  sx={{ color: theme.colors.neutral.black }}
-                  aria-label={onFileRemoveAriaLabel}
-                />
+              <IconButton
+                onClick={handleRemoveFile}
+                aria-label={removeFileAriaLabel}
+                sx={{ p: 0, alignSelf: 'flex-start' }}
+              >
+                <CloseIcon sx={{ color: theme.colors.neutral.black }} />
               </IconButton>
             )}
           </Box>
         )}
       </Box>
+
+      <Input
+        inputProps={{ accept: accept?.join(',') }}
+        type="file"
+        id={id}
+        sx={{ display: 'none' }}
+        required={required}
+        inputRef={uploadInputRef}
+        onChange={handleSelectFile}
+        data-testid="fileInput"
+      />
 
       {helperText && (
         <FormHelperText

--- a/src/components/MISingleFileInput/MISingleFileInput.tsx
+++ b/src/components/MISingleFileInput/MISingleFileInput.tsx
@@ -1,0 +1,537 @@
+'use client';
+
+import { useRef, ChangeEvent, DragEvent, useState } from 'react';
+import {
+  Box,
+  LinearProgress,
+  FormControl,
+  FormLabel,
+  FormHelperText,
+  IconButton,
+  Input,
+  Stack,
+  Typography,
+  useMediaQuery,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+
+/* Icons */
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
+import CloseIcon from '@mui/icons-material/Close';
+import ErrorIcon from '@mui/icons-material/Error';
+import FileUploadOutlinedIcon from '@mui/icons-material/FileUploadOutlined';
+import ReportIcon from '@mui/icons-material/Report';
+
+/* Utils */
+import {
+  generateRandomID,
+  getContainerStyle,
+  getStatus,
+  truncateFileName,
+  verifyAccept,
+} from './utils';
+import { theme } from '@theme';
+import { MIButton } from '@components/MIButton';
+import foundationNext from 'theme/foundations-next/foundationNext';
+
+export type MISingleFileInputProps = {
+  /** The file to be displayed. */
+  value: File | null;
+
+  /** The label of the input */
+  label?: string;
+
+  /** Sets the error status. */
+  error?: boolean;
+
+  /** If true and no file is selected, the component is shown in error state. */
+  required?: boolean;
+
+  /** The MIME types that the input should accept. */
+  accept?: Array<string>;
+
+  /** Sets the loading status */
+  loading?: boolean;
+
+  /** If enabled, sets the icon and the dropzone label alligned vertically. */
+  vertical?: boolean;
+
+  /** Callback called when the file is selected. */
+  onFileSelected: (file: File) => void;
+
+  /** Callback called when the file is removed. */
+  onFileRemoved?: (file: File) => void;
+
+  /** Callback called when the file is rejected. */
+  onFileRejected?: (file: File) => void;
+
+  /** The label to be displayed in the dropzone. */
+  dropzoneLabel: string;
+
+  /** The label to be displayed for the upload button in the dropzone. */
+  dropzoneButton: string;
+
+  /** The support text displayed below the dropzone instruction text. */
+  dropzoneSupportText?: string;
+
+  /** The label to be displayed above the spinner on loading state. */
+  loadingLabel?: string;
+
+  /** If true, forces the drag-over visual state. Useful for static previews. */
+  dragOver?: boolean;
+
+  /**
+   * The label to be displayed when the file is rejected.
+   *
+   * If the label is not provided, the rejected state (on rejected file) will not be displayed.
+   * */
+  rejectedLabel?: string;
+
+  /** If true, forces the rejected visual state. Useful for static previews. */
+  rejected?: boolean;
+
+  /** Label shown for the retry action in rejected status. */
+  retryButtonLabel?: string;
+
+  /** Helper text shown below the container. */
+  helperText?: string;
+};
+
+const formatFileSize = (size: number) => `${Math.max(0, Math.round(size / 1024))} KB`;
+
+const formatLastModified = (timestamp: number) =>
+  new Intl.DateTimeFormat('it-IT', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+    .format(new Date(timestamp))
+    .replace(', ', ',');
+
+export enum UploadStatus {
+  IDLE = 'IDLE',
+  DRAG_OVER = 'DRAG_OVER',
+  LOADING = 'LOADING',
+  REJECTED = 'REJECTED',
+  ERROR = 'ERROR',
+  SELECTED = 'SELECTED',
+}
+
+export const MISingleFileInput = ({
+  value,
+  label,
+  error,
+  required = false,
+  accept,
+  loading,
+  vertical = false,
+
+  onFileSelected,
+  onFileRemoved,
+  onFileRejected,
+  dropzoneLabel,
+  dropzoneButton,
+  dropzoneSupportText,
+  loadingLabel = 'Caricamento in corso...',
+  dragOver = false,
+  rejectedLabel,
+  rejected = false,
+  retryButtonLabel = 'Riprova',
+  helperText,
+}: MISingleFileInputProps): JSX.Element => {
+  const muiTheme = useTheme();
+  const isMobileViewport = useMediaQuery(muiTheme.breakpoints.down('md'));
+  const isVerticalLayout = vertical || isMobileViewport;
+
+  const uploadInputRef = useRef<HTMLInputElement>(null);
+
+  const [id, _] = useState(generateRandomID);
+  const [isFileRejected, setIsFileRejected] = useState(false);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const hasRequiredError = required && !value;
+
+  const status = getStatus(
+    value,
+    !!loading,
+    !!error || hasRequiredError,
+    (rejected || isFileRejected) && !!rejectedLabel,
+    dragOver || isDragOver
+  );
+  const containerStyle = getContainerStyle(status);
+  const typographySemiBoldFontWeight = foundationNext.typography.fontWeightMedium;
+
+  const isDropzoneErrorLike = status === UploadStatus.REJECTED || status === UploadStatus.ERROR;
+  const dropzonePrimaryLabel =
+    status === UploadStatus.REJECTED ? rejectedLabel ?? dropzoneLabel : dropzoneLabel;
+  const showDropzoneActionButton = status !== UploadStatus.DRAG_OVER;
+  const dropzoneButtonLabel = status === UploadStatus.REJECTED ? retryButtonLabel : dropzoneButton;
+
+  const chooseFileHandler = () => {
+    setIsFileRejected(false);
+    setIsDragOver(false);
+
+    const target = uploadInputRef.current;
+    target?.click();
+  };
+
+  const handleDragEnter = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    setIsFileRejected(false);
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    setIsDragOver(false);
+  };
+
+  const handleDragOver = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    e.dataTransfer.dropEffect = 'copy';
+  };
+
+  const handleDrop = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+
+    const droppedFile = e.dataTransfer.files[0];
+    if (!droppedFile) {
+      return;
+    }
+
+    if (verifyAccept(droppedFile.type, accept)) {
+      onFileSelected(droppedFile);
+    } else {
+      setIsFileRejected(true);
+      if (onFileRejected) {
+        onFileRejected(droppedFile);
+      }
+    }
+    e.dataTransfer.clearData();
+  };
+
+  const handleSelectFile = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.item(0);
+    if (file) {
+      setIsFileRejected(false);
+      setIsDragOver(false);
+      onFileSelected(file);
+    }
+  };
+
+  const handleRemoveFile = () => {
+    if (value && onFileRemoved) {
+      onFileRemoved(value);
+    }
+  };
+
+  const showDropzone =
+    status === UploadStatus.IDLE ||
+    status === UploadStatus.DRAG_OVER ||
+    status === UploadStatus.REJECTED ||
+    status === UploadStatus.ERROR;
+
+  const minHeight =
+    status === UploadStatus.SELECTED
+      ? isVerticalLayout
+        ? 118
+        : 94
+      : isVerticalLayout
+      ? 236
+      : status === UploadStatus.DRAG_OVER
+      ? 92
+      : 96;
+
+  return (
+    <FormControl sx={{ width: '100%' }}>
+      <FormLabel error={!!error || hasRequiredError} sx={{ fontWeight: 600, mb: 1 }} htmlFor={id}>
+        {label}
+      </FormLabel>
+
+      <Box
+        sx={{
+          position: 'relative',
+          minHeight,
+          borderRadius: '10px',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          ...containerStyle,
+        }}
+      >
+        {showDropzone && (
+          <Box
+            sx={{
+              cursor: 'pointer',
+              backgroundColor: 'transparent',
+              border: 'none',
+              flex: 1,
+              width: '100%',
+              px: 3,
+              py: isVerticalLayout ? 3 : 0,
+            }}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+            onDragEnter={handleDragEnter}
+            onDragLeave={handleDragLeave}
+            component="button"
+            type="button"
+            onClick={chooseFileHandler}
+            data-testid="loadFromPc"
+          >
+            <Stack
+              direction={isVerticalLayout ? 'column' : 'row'}
+              alignItems="center"
+              justifyContent={isVerticalLayout ? 'center' : 'space-between'}
+              spacing={isVerticalLayout ? 2 : 1}
+              sx={{ width: '100%', height: '100%' }}
+            >
+              <Stack
+                direction={isVerticalLayout ? 'column' : 'row'}
+                spacing={isVerticalLayout ? 1 : 1.5}
+                alignItems="center"
+                sx={{
+                  width: isVerticalLayout ? '100%' : 'auto',
+                  justifyContent: 'center',
+                }}
+              >
+                {status === UploadStatus.REJECTED ? (
+                  <ErrorIcon sx={{ color: theme.colors.error[850] }} />
+                ) : (
+                  <FileUploadOutlinedIcon
+                    sx={{
+                      color: status === UploadStatus.ERROR ? theme.colors.error[850] : undefined,
+                    }}
+                  />
+                )}
+
+                <Stack
+                  spacing={0.5}
+                  sx={{
+                    textAlign: isVerticalLayout ? 'center' : 'left',
+                    width: isVerticalLayout ? '100%' : 'auto',
+                    alignItems: isVerticalLayout ? 'center' : 'flex-start',
+                  }}
+                >
+                  <Typography
+                    display="inline"
+                    variant="body2"
+                    sx={{
+                      fontWeight: typographySemiBoldFontWeight,
+                      color: isDropzoneErrorLike
+                        ? theme.colors.error[850]
+                        : theme.colors.neutral.black,
+                    }}
+                  >
+                    {dropzonePrimaryLabel}
+                  </Typography>
+                  {dropzoneSupportText && (
+                    <Typography
+                      display="inline"
+                      variant="body2"
+                      sx={{
+                        color: isDropzoneErrorLike
+                          ? theme.colors.error[850]
+                          : theme.colors.neutral.grey[700],
+                        fontWeight: typographySemiBoldFontWeight,
+                        fontSize: '12px',
+                        lineHeight: '18px',
+                      }}
+                    >
+                      {dropzoneSupportText}
+                    </Typography>
+                  )}
+                </Stack>
+              </Stack>
+
+              {showDropzoneActionButton && (
+                <MIButton
+                  variant="contained"
+                  color={isDropzoneErrorLike ? 'error' : 'primary'}
+                  sx={{ whiteSpace: 'nowrap' }}
+                >
+                  {dropzoneButtonLabel}
+                </MIButton>
+              )}
+
+              <Input
+                inputProps={{ accept: accept?.join(',') }}
+                type="file"
+                id={id}
+                sx={{ display: 'none' }}
+                required={required}
+                inputRef={uploadInputRef}
+                onChange={handleSelectFile}
+                data-testid="fileInput"
+              />
+            </Stack>
+          </Box>
+        )}
+
+        {status === UploadStatus.LOADING && (
+          <Box p={3} width="100%">
+            <Stack
+              direction={isVerticalLayout ? 'column' : 'row'}
+              justifyContent={isVerticalLayout ? 'center' : 'space-between'}
+              alignItems="center"
+              spacing={3}
+            >
+              <Stack
+                direction="column"
+                spacing={1.5}
+                sx={{
+                  width: '100%',
+                  alignItems: isVerticalLayout ? 'center' : 'flex-start',
+                }}
+              >
+                <Typography
+                  variant="body2"
+                  component="span"
+                  sx={{
+                    fontWeight: typographySemiBoldFontWeight,
+                    textAlign: isVerticalLayout ? 'center' : 'left',
+                  }}
+                >
+                  {loadingLabel}
+                </Typography>
+
+                <LinearProgress
+                  variant="indeterminate"
+                  sx={{
+                    width: '100%',
+                    height: '6px',
+                    '&.MuiLinearProgress-root': {
+                      backgroundColor: theme.colors.neutral.grey[100],
+                      borderRadius: '4px',
+                    },
+                    '& .MuiLinearProgress-bar': {
+                      backgroundColor: theme.colors.blue[500],
+                      width: '32px',
+                      borderRadius: '4px',
+                    },
+                  }}
+                />
+              </Stack>
+
+              {/* Cancel Button */}
+              <MIButton
+                variant="outlined"
+                onClick={handleRemoveFile}
+                sx={{
+                  whiteSpace: 'nowrap',
+                  minWidth: '106px',
+                  fontWeight: 600,
+                  textTransform: 'none',
+                }}
+              >
+                Annulla
+              </MIButton>
+            </Stack>
+          </Box>
+        )}
+
+        {status === UploadStatus.SELECTED && value && (
+          <Box
+            display="flex"
+            justifyContent="space-between"
+            alignItems="flex-start"
+            sx={{ width: '100%', columnGap: 1, py: 3 }}
+          >
+            <CheckCircleRoundedIcon sx={(theme) => ({ mr: 1, color: theme.colors.success[700] })} />
+            <Box
+              display="flex"
+              justifyContent="flex-start"
+              alignItems="flex-start"
+              flexDirection="column"
+              flex={1}
+              minWidth={0}
+            >
+              <Typography
+                fontWeight={typographySemiBoldFontWeight}
+                variant="body2"
+                sx={{
+                  width: '100%',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {truncateFileName(value.name)}
+              </Typography>
+              <Stack
+                direction={isVerticalLayout ? 'column' : 'row'}
+                spacing={isVerticalLayout ? 0.25 : 1}
+                sx={{ width: '100%', minWidth: 0 }}
+              >
+                <Typography
+                  variant="caption"
+                  sx={{
+                    flexShrink: 0,
+                    color: theme.colors.neutral.grey[700],
+                    fontWeight: typographySemiBoldFontWeight,
+                  }}
+                >
+                  {formatFileSize(value.size)}
+                </Typography>
+                {value.lastModified && (
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      minWidth: 0,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      color: theme.colors.neutral.grey[700],
+                    }}
+                  >
+                    {formatLastModified(value.lastModified)}
+                  </Typography>
+                )}
+              </Stack>
+            </Box>
+            {onFileRemoved && (
+              <IconButton onClick={handleRemoveFile} sx={{ p: 0, alignSelf: 'flex-start' }}>
+                <CloseIcon sx={{ color: theme.colors.neutral.black }} />
+              </IconButton>
+            )}
+          </Box>
+        )}
+      </Box>
+
+      {helperText && (
+        <FormHelperText
+          error
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            mt: 1,
+            mx: 3,
+            columnGap: 0.5,
+          }}
+        >
+          {status === UploadStatus.ERROR && <ReportIcon sx={{ fontSize: 16 }} />}
+          <Typography
+            variant="caption"
+            sx={{
+              color: theme.colors.error[600],
+            }}
+          >
+            {helperText}
+          </Typography>
+        </FormHelperText>
+      )}
+    </FormControl>
+  );
+};
+
+export default MISingleFileInput;

--- a/src/components/MISingleFileInput/MISingleFileInput.tsx
+++ b/src/components/MISingleFileInput/MISingleFileInput.tsx
@@ -23,16 +23,12 @@ import FileUploadOutlinedIcon from '@mui/icons-material/FileUploadOutlined';
 import ReportIcon from '@mui/icons-material/Report';
 
 /* Utils */
-import {
-  generateRandomID,
-  getContainerStyle,
-  getStatus,
-  truncateFileName,
-  verifyAccept,
-} from './utils';
+import { getContainerStyle, getStatus } from './utils';
 import { theme } from '@theme';
 import { MIButton } from '@components/MIButton';
 import foundationNext from 'theme/foundations-next/foundationNext';
+import { UploadStatus } from 'types/singleFileInput';
+import { generateRandomID, verifyAccept, truncateFileName } from 'utils/singleFileInput';
 
 export type MISingleFileInputProps = {
   /** The file to be displayed. */
@@ -110,15 +106,6 @@ const formatLastModified = (timestamp: number) =>
   })
     .format(new Date(timestamp))
     .replace(', ', ',');
-
-export enum UploadStatus {
-  IDLE = 'IDLE',
-  DRAG_OVER = 'DRAG_OVER',
-  LOADING = 'LOADING',
-  REJECTED = 'REJECTED',
-  ERROR = 'ERROR',
-  SELECTED = 'SELECTED',
-}
 
 export const MISingleFileInput = ({
   value,

--- a/src/components/MISingleFileInput/MISingleFileInput.tsx
+++ b/src/components/MISingleFileInput/MISingleFileInput.tsx
@@ -109,6 +109,450 @@ const formatLastModified = (timestamp: number) =>
     .format(new Date(timestamp))
     .replace(', ', ',');
 
+type DropzoneStateProps = {
+  status: UploadStatus;
+  isVerticalLayout: boolean;
+  dropzoneLabel: string;
+  rejectedLabel?: string;
+  dropzoneSupportText?: string;
+  retryButtonLabel: string;
+  dropzoneButton: string;
+  typographySemiBoldFontWeight: string | number | undefined;
+  dropzonePrimaryLabelId: string;
+  dropzoneSupportTextId: string;
+  dropzoneAriaLabel: string;
+  chooseFileHandler: () => void;
+  handleDragOver: (e: DragEvent) => void;
+  handleDrop: (e: DragEvent) => void;
+  handleDragEnter: (e: DragEvent) => void;
+  handleDragLeave: (e: DragEvent) => void;
+};
+
+const DropzoneState = ({
+  status,
+  isVerticalLayout,
+  dropzoneLabel,
+  rejectedLabel,
+  dropzoneSupportText,
+  retryButtonLabel,
+  dropzoneButton,
+  typographySemiBoldFontWeight,
+  dropzonePrimaryLabelId,
+  dropzoneSupportTextId,
+  dropzoneAriaLabel,
+  chooseFileHandler,
+  handleDragOver,
+  handleDrop,
+  handleDragEnter,
+  handleDragLeave,
+}: DropzoneStateProps): JSX.Element => {
+  const isDropzoneErrorLike = status === UploadStatus.REJECTED || status === UploadStatus.ERROR;
+  const dropzonePrimaryLabel =
+    status === UploadStatus.REJECTED ? rejectedLabel ?? dropzoneLabel : dropzoneLabel;
+  const showDropzoneActionButton = status !== UploadStatus.DRAG_OVER;
+  const dropzoneButtonLabel = status === UploadStatus.REJECTED ? retryButtonLabel : dropzoneButton;
+
+  return (
+    <Box
+      sx={{
+        cursor: 'pointer',
+        backgroundColor: 'transparent',
+        border: 'none',
+        flex: 1,
+        width: '100%',
+        p: 3,
+      }}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      component="div"
+      onClick={chooseFileHandler}
+      data-testid="loadFromPc"
+    >
+      <Stack
+        direction={isVerticalLayout ? 'column' : 'row'}
+        alignItems="center"
+        justifyContent={isVerticalLayout ? 'center' : 'space-between'}
+        spacing={isVerticalLayout ? 2 : 1}
+        sx={{ width: '100%', height: '100%' }}
+      >
+        <Stack
+          direction={isVerticalLayout ? 'column' : 'row'}
+          spacing={isVerticalLayout ? 1 : 1.5}
+          alignItems="center"
+          sx={{
+            width: isVerticalLayout ? '100%' : 'auto',
+            justifyContent: 'center',
+          }}
+        >
+          {status === UploadStatus.REJECTED ? (
+            <ErrorIcon sx={{ color: theme.colors.error[850] }} />
+          ) : (
+            <FileUploadOutlinedIcon
+              sx={{
+                color: status === UploadStatus.ERROR ? theme.colors.error[850] : undefined,
+              }}
+            />
+          )}
+
+          <Stack
+            spacing={0.5}
+            sx={{
+              textAlign: isVerticalLayout ? 'center' : 'left',
+              width: isVerticalLayout ? '100%' : 'auto',
+              alignItems: isVerticalLayout ? 'center' : 'flex-start',
+            }}
+          >
+            <Typography
+              id={dropzonePrimaryLabelId}
+              display="inline"
+              variant="body2"
+              sx={{
+                fontWeight: typographySemiBoldFontWeight,
+                color: isDropzoneErrorLike ? theme.colors.error[850] : theme.colors.neutral.black,
+              }}
+            >
+              {dropzonePrimaryLabel}
+            </Typography>
+            {dropzoneSupportText && (
+              <Typography
+                id={dropzoneSupportTextId}
+                display="inline"
+                variant="body2"
+                sx={{
+                  color: isDropzoneErrorLike
+                    ? theme.colors.error[850]
+                    : theme.colors.neutral.grey[700],
+                  fontWeight: typographySemiBoldFontWeight,
+                  fontSize: '12px',
+                  lineHeight: '18px',
+                }}
+              >
+                {dropzoneSupportText}
+              </Typography>
+            )}
+          </Stack>
+        </Stack>
+
+        {showDropzoneActionButton && (
+          <MIButton
+            variant="contained"
+            color={isDropzoneErrorLike ? 'error' : 'primary'}
+            sx={{ whiteSpace: 'nowrap' }}
+            aria-label={dropzoneAriaLabel}
+            onClick={(event) => {
+              event.stopPropagation();
+              chooseFileHandler();
+            }}
+          >
+            {dropzoneButtonLabel}
+          </MIButton>
+        )}
+      </Stack>
+    </Box>
+  );
+};
+
+type LoadingStateProps = {
+  isVerticalLayout: boolean;
+  typographySemiBoldFontWeight: string | number | undefined;
+  loadingLabel: string;
+  loadingAriaLabel: string;
+  cancelButtonLabel: string;
+  handleRemoveFile: () => void;
+};
+
+const LoadingState = ({
+  isVerticalLayout,
+  typographySemiBoldFontWeight,
+  loadingLabel,
+  loadingAriaLabel,
+  cancelButtonLabel,
+  handleRemoveFile,
+}: LoadingStateProps): JSX.Element => (
+  <Box p={3} width="100%">
+    <Stack
+      direction={isVerticalLayout ? 'column' : 'row'}
+      justifyContent={isVerticalLayout ? 'center' : 'space-between'}
+      alignItems="center"
+      spacing={3}
+    >
+      <Stack
+        direction="column"
+        spacing={1.5}
+        sx={{
+          width: '100%',
+          alignItems: isVerticalLayout ? 'center' : 'flex-start',
+        }}
+      >
+        <Typography
+          variant="body2"
+          component="span"
+          sx={{
+            fontWeight: typographySemiBoldFontWeight,
+            textAlign: isVerticalLayout ? 'center' : 'left',
+          }}
+        >
+          {loadingLabel}
+        </Typography>
+
+        <LinearProgress
+          variant="indeterminate"
+          sx={{
+            width: '100%',
+            height: '6px',
+            '&.MuiLinearProgress-root': {
+              backgroundColor: theme.colors.neutral.grey[100],
+              borderRadius: '4px',
+            },
+            '& .MuiLinearProgress-bar': {
+              backgroundColor: theme.colors.blue[500],
+              width: '32px',
+              borderRadius: '4px',
+            },
+          }}
+        />
+      </Stack>
+
+      <MIButton
+        variant="outlined"
+        aria-label={loadingAriaLabel}
+        onClick={handleRemoveFile}
+        sx={{
+          whiteSpace: 'nowrap',
+          minWidth: '106px',
+          fontWeight: 600,
+          textTransform: 'none',
+        }}
+      >
+        {cancelButtonLabel}
+      </MIButton>
+    </Stack>
+  </Box>
+);
+
+type SelectedStateProps = {
+  isVerticalLayout: boolean;
+  value: File;
+  onFileRemoved?: (file: File) => void;
+  handleRemoveFile: () => void;
+  removeFileAriaLabel: string;
+  typographySemiBoldFontWeight: string | number | undefined;
+};
+
+const SelectedState = ({
+  isVerticalLayout,
+  value,
+  onFileRemoved,
+  handleRemoveFile,
+  removeFileAriaLabel,
+  typographySemiBoldFontWeight,
+}: SelectedStateProps): JSX.Element => (
+  <Box
+    display="flex"
+    justifyContent="space-between"
+    alignItems="flex-start"
+    sx={{ width: '100%', columnGap: 1, py: 3 }}
+  >
+    <CheckCircleRoundedIcon sx={(theme) => ({ mr: 1, color: theme.colors.success[700] })} />
+    <Box
+      display="flex"
+      justifyContent="flex-start"
+      alignItems="flex-start"
+      flexDirection="column"
+      flex={1}
+      minWidth={0}
+    >
+      <Typography
+        fontWeight={typographySemiBoldFontWeight}
+        variant="body2"
+        sx={{
+          width: '100%',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {truncateFileName(value.name)}
+      </Typography>
+      <Stack
+        direction={isVerticalLayout ? 'column' : 'row'}
+        spacing={isVerticalLayout ? 0.25 : 1}
+        sx={{ width: '100%', minWidth: 0 }}
+      >
+        <Typography
+          variant="caption"
+          sx={{
+            flexShrink: 0,
+            color: theme.colors.neutral.grey[700],
+            fontWeight: typographySemiBoldFontWeight,
+          }}
+        >
+          {formatFileSize(value.size)}
+        </Typography>
+        {value.lastModified && (
+          <Typography
+            variant="caption"
+            sx={{
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              color: theme.colors.neutral.grey[700],
+            }}
+          >
+            {formatLastModified(value.lastModified)}
+          </Typography>
+        )}
+      </Stack>
+    </Box>
+    {onFileRemoved && (
+      <IconButton
+        onClick={handleRemoveFile}
+        aria-label={removeFileAriaLabel}
+        sx={{ p: 0, alignSelf: 'flex-start' }}
+      >
+        <CloseIcon sx={{ color: theme.colors.neutral.black }} />
+      </IconButton>
+    )}
+  </Box>
+);
+
+type StatusContentProps = {
+  status: UploadStatus;
+  value: File | null;
+  isVerticalLayout: boolean;
+  dropzoneLabel: string;
+  rejectedLabel?: string;
+  dropzoneSupportText?: string;
+  retryButtonLabel: string;
+  dropzoneButton: string;
+  typographySemiBoldFontWeight: string | number | undefined;
+  dropzonePrimaryLabelId: string;
+  dropzoneSupportTextId: string;
+  dropzoneAriaLabel: string;
+  loadingLabel: string;
+  loadingAriaLabel: string;
+  cancelButtonLabel: string;
+  onFileRemoved?: (file: File) => void;
+  removeFileAriaLabel: string;
+  chooseFileHandler: () => void;
+  handleDragOver: (e: DragEvent) => void;
+  handleDrop: (e: DragEvent) => void;
+  handleDragEnter: (e: DragEvent) => void;
+  handleDragLeave: (e: DragEvent) => void;
+  handleRemoveFile: () => void;
+};
+
+const StatusContent = ({
+  status,
+  value,
+  isVerticalLayout,
+  dropzoneLabel,
+  rejectedLabel,
+  dropzoneSupportText,
+  retryButtonLabel,
+  dropzoneButton,
+  typographySemiBoldFontWeight,
+  dropzonePrimaryLabelId,
+  dropzoneSupportTextId,
+  dropzoneAriaLabel,
+  loadingLabel,
+  loadingAriaLabel,
+  cancelButtonLabel,
+  onFileRemoved,
+  removeFileAriaLabel,
+  chooseFileHandler,
+  handleDragOver,
+  handleDrop,
+  handleDragEnter,
+  handleDragLeave,
+  handleRemoveFile,
+}: StatusContentProps): JSX.Element => {
+  if (status === UploadStatus.LOADING) {
+    return (
+      <LoadingState
+        isVerticalLayout={isVerticalLayout}
+        typographySemiBoldFontWeight={typographySemiBoldFontWeight}
+        loadingLabel={loadingLabel}
+        loadingAriaLabel={loadingAriaLabel}
+        cancelButtonLabel={cancelButtonLabel}
+        handleRemoveFile={handleRemoveFile}
+      />
+    );
+  }
+
+  if (status === UploadStatus.SELECTED && value) {
+    return (
+      <SelectedState
+        isVerticalLayout={isVerticalLayout}
+        value={value}
+        onFileRemoved={onFileRemoved}
+        handleRemoveFile={handleRemoveFile}
+        removeFileAriaLabel={removeFileAriaLabel}
+        typographySemiBoldFontWeight={typographySemiBoldFontWeight}
+      />
+    );
+  }
+
+  return (
+    <DropzoneState
+      status={status}
+      isVerticalLayout={isVerticalLayout}
+      dropzoneLabel={dropzoneLabel}
+      rejectedLabel={rejectedLabel}
+      dropzoneSupportText={dropzoneSupportText}
+      retryButtonLabel={retryButtonLabel}
+      dropzoneButton={dropzoneButton}
+      typographySemiBoldFontWeight={typographySemiBoldFontWeight}
+      dropzonePrimaryLabelId={dropzonePrimaryLabelId}
+      dropzoneSupportTextId={dropzoneSupportTextId}
+      dropzoneAriaLabel={dropzoneAriaLabel}
+      chooseFileHandler={chooseFileHandler}
+      handleDragOver={handleDragOver}
+      handleDrop={handleDrop}
+      handleDragEnter={handleDragEnter}
+      handleDragLeave={handleDragLeave}
+    />
+  );
+};
+
+const HelperTextSection = ({
+  helperText,
+  status,
+}: {
+  helperText?: string;
+  status: UploadStatus;
+}): JSX.Element | null => {
+  if (!helperText) {
+    return null;
+  }
+
+  return (
+    <FormHelperText
+      error
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        mt: 0.5,
+        mx: 3,
+        columnGap: 0.5,
+      }}
+    >
+      {status === UploadStatus.ERROR && <ReportIcon sx={{ fontSize: 16 }} />}
+      <Typography
+        variant="caption"
+        sx={{
+          color: theme.colors.error[600],
+        }}
+      >
+        {helperText}
+      </Typography>
+    </FormHelperText>
+  );
+};
+
 export const MISingleFileInput = ({
   value,
   label,
@@ -137,7 +581,7 @@ export const MISingleFileInput = ({
 
   const uploadInputRef = useRef<HTMLInputElement>(null);
 
-  const [id, _] = useState(generateRandomID);
+  const [id] = useState(generateRandomID);
   const [isFileRejected, setIsFileRejected] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
 
@@ -150,18 +594,17 @@ export const MISingleFileInput = ({
   );
   const containerStyle = getContainerStyle(status);
   const typographySemiBoldFontWeight = foundationNext.typography.fontWeightMedium;
-
-  const isDropzoneErrorLike = status === UploadStatus.REJECTED || status === UploadStatus.ERROR;
-  const dropzonePrimaryLabel =
-    status === UploadStatus.REJECTED ? rejectedLabel ?? dropzoneLabel : dropzoneLabel;
-  const showDropzoneActionButton = status !== UploadStatus.DRAG_OVER;
-  const dropzoneButtonLabel = status === UploadStatus.REJECTED ? retryButtonLabel : dropzoneButton;
   const dropzonePrimaryLabelId = `${id}-dropzone-primary-label`;
   const dropzoneSupportTextId = `${id}-dropzone-support-text`;
 
+  const dropzonePrimaryLabelForAria =
+    status === UploadStatus.REJECTED ? rejectedLabel ?? dropzoneLabel : dropzoneLabel;
+  const dropzoneButtonLabelForAria =
+    status === UploadStatus.REJECTED ? retryButtonLabel : dropzoneButton;
+
   const dropzoneAriaLabel = [
-    dropzoneButtonLabel,
-    dropzonePrimaryLabel,
+    dropzoneButtonLabelForAria,
+    dropzonePrimaryLabelForAria,
     dropzoneSupportText,
     helperText,
   ]
@@ -206,9 +649,6 @@ export const MISingleFileInput = ({
     setIsDragOver(false);
 
     const droppedFile = e.dataTransfer.files[0];
-    if (!droppedFile) {
-      return;
-    }
 
     if (verifyAccept(droppedFile.type, accept)) {
       onFileSelected(droppedFile);
@@ -236,12 +676,6 @@ export const MISingleFileInput = ({
     }
   };
 
-  const showDropzone =
-    status === UploadStatus.IDLE ||
-    status === UploadStatus.DRAG_OVER ||
-    status === UploadStatus.REJECTED ||
-    status === UploadStatus.ERROR;
-
   return (
     <FormControl sx={{ width: '100%' }}>
       <FormLabel error={!!error} sx={{ fontWeight: 600, mb: 1 }} htmlFor={id}>
@@ -258,242 +692,31 @@ export const MISingleFileInput = ({
           ...containerStyle,
         }}
       >
-        {showDropzone && (
-          <Box
-            sx={{
-              cursor: 'pointer',
-              backgroundColor: 'transparent',
-              border: 'none',
-              flex: 1,
-              width: '100%',
-              p: 3,
-            }}
-            onDragOver={handleDragOver}
-            onDrop={handleDrop}
-            onDragEnter={handleDragEnter}
-            onDragLeave={handleDragLeave}
-            component="div"
-            onClick={chooseFileHandler}
-            data-testid="loadFromPc"
-          >
-            <Stack
-              direction={isVerticalLayout ? 'column' : 'row'}
-              alignItems="center"
-              justifyContent={isVerticalLayout ? 'center' : 'space-between'}
-              spacing={isVerticalLayout ? 2 : 1}
-              sx={{ width: '100%', height: '100%' }}
-            >
-              <Stack
-                direction={isVerticalLayout ? 'column' : 'row'}
-                spacing={isVerticalLayout ? 1 : 1.5}
-                alignItems="center"
-                sx={{
-                  width: isVerticalLayout ? '100%' : 'auto',
-                  justifyContent: 'center',
-                }}
-              >
-                {status === UploadStatus.REJECTED ? (
-                  <ErrorIcon sx={{ color: theme.colors.error[850] }} />
-                ) : (
-                  <FileUploadOutlinedIcon
-                    sx={{
-                      color: status === UploadStatus.ERROR ? theme.colors.error[850] : undefined,
-                    }}
-                  />
-                )}
-
-                <Stack
-                  spacing={0.5}
-                  sx={{
-                    textAlign: isVerticalLayout ? 'center' : 'left',
-                    width: isVerticalLayout ? '100%' : 'auto',
-                    alignItems: isVerticalLayout ? 'center' : 'flex-start',
-                  }}
-                >
-                  <Typography
-                    id={dropzonePrimaryLabelId}
-                    display="inline"
-                    variant="body2"
-                    sx={{
-                      fontWeight: typographySemiBoldFontWeight,
-                      color: isDropzoneErrorLike
-                        ? theme.colors.error[850]
-                        : theme.colors.neutral.black,
-                    }}
-                  >
-                    {dropzonePrimaryLabel}
-                  </Typography>
-                  {dropzoneSupportText && (
-                    <Typography
-                      id={dropzoneSupportTextId}
-                      display="inline"
-                      variant="body2"
-                      sx={{
-                        color: isDropzoneErrorLike
-                          ? theme.colors.error[850]
-                          : theme.colors.neutral.grey[700],
-                        fontWeight: typographySemiBoldFontWeight,
-                        fontSize: '12px',
-                        lineHeight: '18px',
-                      }}
-                    >
-                      {dropzoneSupportText}
-                    </Typography>
-                  )}
-                </Stack>
-              </Stack>
-
-              {showDropzoneActionButton && (
-                <MIButton
-                  variant="contained"
-                  color={isDropzoneErrorLike ? 'error' : 'primary'}
-                  sx={{ whiteSpace: 'nowrap' }}
-                  aria-label={dropzoneAriaLabel}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    chooseFileHandler();
-                  }}
-                >
-                  {dropzoneButtonLabel}
-                </MIButton>
-              )}
-            </Stack>
-          </Box>
-        )}
-
-        {status === UploadStatus.LOADING && (
-          <Box p={3} width="100%">
-            <Stack
-              direction={isVerticalLayout ? 'column' : 'row'}
-              justifyContent={isVerticalLayout ? 'center' : 'space-between'}
-              alignItems="center"
-              spacing={3}
-            >
-              <Stack
-                direction="column"
-                spacing={1.5}
-                sx={{
-                  width: '100%',
-                  alignItems: isVerticalLayout ? 'center' : 'flex-start',
-                }}
-              >
-                <Typography
-                  variant="body2"
-                  component="span"
-                  sx={{
-                    fontWeight: typographySemiBoldFontWeight,
-                    textAlign: isVerticalLayout ? 'center' : 'left',
-                  }}
-                >
-                  {loadingLabel}
-                </Typography>
-
-                <LinearProgress
-                  variant="indeterminate"
-                  sx={{
-                    width: '100%',
-                    height: '6px',
-                    '&.MuiLinearProgress-root': {
-                      backgroundColor: theme.colors.neutral.grey[100],
-                      borderRadius: '4px',
-                    },
-                    '& .MuiLinearProgress-bar': {
-                      backgroundColor: theme.colors.blue[500],
-                      width: '32px',
-                      borderRadius: '4px',
-                    },
-                  }}
-                />
-              </Stack>
-
-              {/* Cancel Button */}
-              <MIButton
-                variant="outlined"
-                aria-label={loadingAriaLabel}
-                onClick={handleRemoveFile}
-                sx={{
-                  whiteSpace: 'nowrap',
-                  minWidth: '106px',
-                  fontWeight: 600,
-                  textTransform: 'none',
-                }}
-              >
-                {cancelButtonLabel}
-              </MIButton>
-            </Stack>
-          </Box>
-        )}
-
-        {status === UploadStatus.SELECTED && value && (
-          <Box
-            display="flex"
-            justifyContent="space-between"
-            alignItems="flex-start"
-            sx={{ width: '100%', columnGap: 1, py: 3 }}
-          >
-            <CheckCircleRoundedIcon sx={(theme) => ({ mr: 1, color: theme.colors.success[700] })} />
-            <Box
-              display="flex"
-              justifyContent="flex-start"
-              alignItems="flex-start"
-              flexDirection="column"
-              flex={1}
-              minWidth={0}
-            >
-              <Typography
-                fontWeight={typographySemiBoldFontWeight}
-                variant="body2"
-                sx={{
-                  width: '100%',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {truncateFileName(value.name)}
-              </Typography>
-              <Stack
-                direction={isVerticalLayout ? 'column' : 'row'}
-                spacing={isVerticalLayout ? 0.25 : 1}
-                sx={{ width: '100%', minWidth: 0 }}
-              >
-                <Typography
-                  variant="caption"
-                  sx={{
-                    flexShrink: 0,
-                    color: theme.colors.neutral.grey[700],
-                    fontWeight: typographySemiBoldFontWeight,
-                  }}
-                >
-                  {formatFileSize(value.size)}
-                </Typography>
-                {value.lastModified && (
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      minWidth: 0,
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                      color: theme.colors.neutral.grey[700],
-                    }}
-                  >
-                    {formatLastModified(value.lastModified)}
-                  </Typography>
-                )}
-              </Stack>
-            </Box>
-            {onFileRemoved && (
-              <IconButton
-                onClick={handleRemoveFile}
-                aria-label={removeFileAriaLabel}
-                sx={{ p: 0, alignSelf: 'flex-start' }}
-              >
-                <CloseIcon sx={{ color: theme.colors.neutral.black }} />
-              </IconButton>
-            )}
-          </Box>
-        )}
+        <StatusContent
+          status={status}
+          value={value}
+          isVerticalLayout={isVerticalLayout}
+          dropzoneLabel={dropzoneLabel}
+          rejectedLabel={rejectedLabel}
+          dropzoneSupportText={dropzoneSupportText}
+          retryButtonLabel={retryButtonLabel}
+          dropzoneButton={dropzoneButton}
+          typographySemiBoldFontWeight={typographySemiBoldFontWeight}
+          dropzonePrimaryLabelId={dropzonePrimaryLabelId}
+          dropzoneSupportTextId={dropzoneSupportTextId}
+          dropzoneAriaLabel={dropzoneAriaLabel}
+          loadingLabel={loadingLabel}
+          loadingAriaLabel={loadingAriaLabel}
+          cancelButtonLabel={cancelButtonLabel}
+          onFileRemoved={onFileRemoved}
+          removeFileAriaLabel={removeFileAriaLabel}
+          chooseFileHandler={chooseFileHandler}
+          handleDragOver={handleDragOver}
+          handleDrop={handleDrop}
+          handleDragEnter={handleDragEnter}
+          handleDragLeave={handleDragLeave}
+          handleRemoveFile={handleRemoveFile}
+        />
       </Box>
 
       <Input
@@ -506,28 +729,7 @@ export const MISingleFileInput = ({
         data-testid="fileInput"
       />
 
-      {helperText && (
-        <FormHelperText
-          error
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            mt: 0.5,
-            mx: 3,
-            columnGap: 0.5,
-          }}
-        >
-          {status === UploadStatus.ERROR && <ReportIcon sx={{ fontSize: 16 }} />}
-          <Typography
-            variant="caption"
-            sx={{
-              color: theme.colors.error[600],
-            }}
-          >
-            {helperText}
-          </Typography>
-        </FormHelperText>
-      )}
+      <HelperTextSection helperText={helperText} status={status} />
     </FormControl>
   );
 };

--- a/src/components/MISingleFileInput/MISingleFileInput.tsx
+++ b/src/components/MISingleFileInput/MISingleFileInput.tsx
@@ -40,17 +40,11 @@ export type MISingleFileInputProps = {
   /** Sets the error status. */
   error?: boolean;
 
-  /** If true and no file is selected, the component is shown in error state. */
-  required?: boolean;
-
   /** The MIME types that the input should accept. */
   accept?: Array<string>;
 
   /** Sets the loading status */
   loading?: boolean;
-
-  /** If enabled, sets the icon and the dropzone label alligned vertically. */
-  vertical?: boolean;
 
   /** Callback called when the file is selected. */
   onFileSelected: (file: File) => void;
@@ -117,7 +111,6 @@ export const MISingleFileInput = ({
   value,
   label,
   error,
-  required = false,
   accept,
   loading,
 
@@ -145,12 +138,11 @@ export const MISingleFileInput = ({
   const [id, _] = useState(generateRandomID);
   const [isFileRejected, setIsFileRejected] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
-  const hasRequiredError = required && !value;
 
   const status = getStatus(
     value,
     !!loading,
-    !!error || hasRequiredError,
+    !!error,
     (rejected || isFileRejected) && !!rejectedLabel,
     dragOver || isDragOver
   );
@@ -165,7 +157,12 @@ export const MISingleFileInput = ({
   const dropzonePrimaryLabelId = `${id}-dropzone-primary-label`;
   const dropzoneSupportTextId = `${id}-dropzone-support-text`;
 
-  const dropzoneAriaLabel = [dropzoneButtonLabel, dropzonePrimaryLabel, dropzoneSupportText]
+  const dropzoneAriaLabel = [
+    dropzoneButtonLabel,
+    dropzonePrimaryLabel,
+    dropzoneSupportText,
+    helperText,
+  ]
     .filter(Boolean)
     .join('. ');
   const loadingAriaLabel = [loadingLabel, cancelButtonLabel].filter(Boolean).join('. ');
@@ -245,7 +242,7 @@ export const MISingleFileInput = ({
 
   return (
     <FormControl sx={{ width: '100%' }}>
-      <FormLabel error={!!error || hasRequiredError} sx={{ fontWeight: 600, mb: 1 }} htmlFor={id}>
+      <FormLabel error={!!error} sx={{ fontWeight: 600, mb: 1 }} htmlFor={id}>
         {label}
       </FormLabel>
 
@@ -502,7 +499,6 @@ export const MISingleFileInput = ({
         type="file"
         id={id}
         sx={{ display: 'none' }}
-        required={required}
         inputRef={uploadInputRef}
         onChange={handleSelectFile}
         data-testid="fileInput"

--- a/src/components/MISingleFileInput/MISingleFileInput.tsx
+++ b/src/components/MISingleFileInput/MISingleFileInput.tsx
@@ -128,6 +128,85 @@ type DropzoneStateProps = {
   handleDragLeave: (e: DragEvent) => void;
 };
 
+type DropzoneLayout = {
+  rootDirection: 'column' | 'row';
+  rootJustifyContent: 'center' | 'space-between';
+  rootSpacing: number;
+  contentDirection: 'column' | 'row';
+  contentSpacing: number;
+  contentWidth: '100%' | 'auto';
+  contentJustifyContent: 'center';
+  labelTextAlign: 'center' | 'left';
+  labelWidth: '100%' | 'auto';
+  labelAlignItems: 'center' | 'flex-start';
+};
+
+type DropzoneVisualState = {
+  isDropzoneErrorLike: boolean;
+  primaryLabel: string;
+  actionButtonLabel: string;
+  supportTextColor: string;
+  primaryLabelColor: string;
+  actionButtonColor: 'error' | 'primary';
+  showErrorIcon: boolean;
+  showUploadErrorColor: boolean;
+};
+
+const getDropzoneLayout = (isVerticalLayout: boolean): DropzoneLayout => {
+  if (isVerticalLayout) {
+    return {
+      rootDirection: 'column',
+      rootJustifyContent: 'center',
+      rootSpacing: 2,
+      contentDirection: 'column',
+      contentSpacing: 1,
+      contentWidth: '100%',
+      contentJustifyContent: 'center',
+      labelTextAlign: 'center',
+      labelWidth: '100%',
+      labelAlignItems: 'center',
+    };
+  }
+
+  return {
+    rootDirection: 'row',
+    rootJustifyContent: 'space-between',
+    rootSpacing: 1,
+    contentDirection: 'row',
+    contentSpacing: 1.5,
+    contentWidth: 'auto',
+    contentJustifyContent: 'center',
+    labelTextAlign: 'left',
+    labelWidth: 'auto',
+    labelAlignItems: 'flex-start',
+  };
+};
+
+const getDropzoneVisualState = (
+  status: UploadStatus,
+  dropzoneLabel: string,
+  rejectedLabel: string | undefined,
+  retryButtonLabel: string,
+  dropzoneButton: string
+): DropzoneVisualState => {
+  const isRejected = status === UploadStatus.REJECTED;
+  const isError = status === UploadStatus.ERROR;
+  const isDropzoneErrorLike = isRejected || isError;
+
+  return {
+    isDropzoneErrorLike,
+    primaryLabel: isRejected ? rejectedLabel ?? dropzoneLabel : dropzoneLabel,
+    actionButtonLabel: isRejected ? retryButtonLabel : dropzoneButton,
+    supportTextColor: isDropzoneErrorLike
+      ? theme.colors.error[850]
+      : theme.colors.neutral.grey[700],
+    primaryLabelColor: isDropzoneErrorLike ? theme.colors.error[850] : theme.colors.neutral.black,
+    actionButtonColor: isDropzoneErrorLike ? 'error' : 'primary',
+    showErrorIcon: isRejected,
+    showUploadErrorColor: isError,
+  };
+};
+
 const DropzoneState = ({
   status,
   isVerticalLayout,
@@ -146,11 +225,15 @@ const DropzoneState = ({
   handleDragEnter,
   handleDragLeave,
 }: DropzoneStateProps): JSX.Element => {
-  const isDropzoneErrorLike = status === UploadStatus.REJECTED || status === UploadStatus.ERROR;
-  const dropzonePrimaryLabel =
-    status === UploadStatus.REJECTED ? rejectedLabel ?? dropzoneLabel : dropzoneLabel;
+  const layout = getDropzoneLayout(isVerticalLayout);
+  const visualState = getDropzoneVisualState(
+    status,
+    dropzoneLabel,
+    rejectedLabel,
+    retryButtonLabel,
+    dropzoneButton
+  );
   const showDropzoneActionButton = status !== UploadStatus.DRAG_OVER;
-  const dropzoneButtonLabel = status === UploadStatus.REJECTED ? retryButtonLabel : dropzoneButton;
 
   return (
     <Box
@@ -171,27 +254,27 @@ const DropzoneState = ({
       data-testid="loadFromPc"
     >
       <Stack
-        direction={isVerticalLayout ? 'column' : 'row'}
+        direction={layout.rootDirection}
         alignItems="center"
-        justifyContent={isVerticalLayout ? 'center' : 'space-between'}
-        spacing={isVerticalLayout ? 2 : 1}
+        justifyContent={layout.rootJustifyContent}
+        spacing={layout.rootSpacing}
         sx={{ width: '100%', height: '100%' }}
       >
         <Stack
-          direction={isVerticalLayout ? 'column' : 'row'}
-          spacing={isVerticalLayout ? 1 : 1.5}
+          direction={layout.contentDirection}
+          spacing={layout.contentSpacing}
           alignItems="center"
           sx={{
-            width: isVerticalLayout ? '100%' : 'auto',
-            justifyContent: 'center',
+            width: layout.contentWidth,
+            justifyContent: layout.contentJustifyContent,
           }}
         >
-          {status === UploadStatus.REJECTED ? (
+          {visualState.showErrorIcon ? (
             <ErrorIcon sx={{ color: theme.colors.error[850] }} />
           ) : (
             <FileUploadOutlinedIcon
               sx={{
-                color: status === UploadStatus.ERROR ? theme.colors.error[850] : undefined,
+                color: visualState.showUploadErrorColor ? theme.colors.error[850] : undefined,
               }}
             />
           )}
@@ -199,9 +282,9 @@ const DropzoneState = ({
           <Stack
             spacing={0.5}
             sx={{
-              textAlign: isVerticalLayout ? 'center' : 'left',
-              width: isVerticalLayout ? '100%' : 'auto',
-              alignItems: isVerticalLayout ? 'center' : 'flex-start',
+              textAlign: layout.labelTextAlign,
+              width: layout.labelWidth,
+              alignItems: layout.labelAlignItems,
             }}
           >
             <Typography
@@ -210,10 +293,10 @@ const DropzoneState = ({
               variant="body2"
               sx={{
                 fontWeight: typographySemiBoldFontWeight,
-                color: isDropzoneErrorLike ? theme.colors.error[850] : theme.colors.neutral.black,
+                color: visualState.primaryLabelColor,
               }}
             >
-              {dropzonePrimaryLabel}
+              {visualState.primaryLabel}
             </Typography>
             {dropzoneSupportText && (
               <Typography
@@ -221,9 +304,7 @@ const DropzoneState = ({
                 display="inline"
                 variant="body2"
                 sx={{
-                  color: isDropzoneErrorLike
-                    ? theme.colors.error[850]
-                    : theme.colors.neutral.grey[700],
+                  color: visualState.supportTextColor,
                   fontWeight: typographySemiBoldFontWeight,
                   fontSize: '12px',
                   lineHeight: '18px',
@@ -238,7 +319,7 @@ const DropzoneState = ({
         {showDropzoneActionButton && (
           <MIButton
             variant="contained"
-            color={isDropzoneErrorLike ? 'error' : 'primary'}
+            color={visualState.actionButtonColor}
             sx={{ whiteSpace: 'nowrap' }}
             aria-label={dropzoneAriaLabel}
             onClick={(event) => {
@@ -246,7 +327,7 @@ const DropzoneState = ({
               chooseFileHandler();
             }}
           >
-            {dropzoneButtonLabel}
+            {visualState.actionButtonLabel}
           </MIButton>
         )}
       </Stack>

--- a/src/components/MISingleFileInput/MISingleFileInput.tsx
+++ b/src/components/MISingleFileInput/MISingleFileInput.tsx
@@ -16,19 +16,21 @@ import {
 import { useTheme } from '@mui/material/styles';
 
 /* Icons */
-import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
-import CloseIcon from '@mui/icons-material/Close';
-import ErrorIcon from '@mui/icons-material/Error';
-import FileUploadOutlinedIcon from '@mui/icons-material/FileUploadOutlined';
-import ReportIcon from '@mui/icons-material/Report';
+import {
+  CheckCircleRounded as CheckCircleRoundedIcon,
+  Close as CloseIcon,
+  Error as ErrorIcon,
+  FileUploadOutlined as FileUploadOutlinedIcon,
+  Report as ReportIcon,
+} from '@mui/icons-material';
 
 /* Utils */
-import { getContainerStyle, getStatus } from './utils';
 import { theme } from '@theme';
 import { MIButton } from '@components/MIButton';
 import foundationNext from 'theme/foundations-next/foundationNext';
 import { UploadStatus } from 'types/singleFileInput';
 import { generateRandomID, verifyAccept, truncateFileName } from 'utils/singleFileInput';
+import { getContainerStyle, getStatus } from './utils';
 
 export type MISingleFileInputProps = {
   /** The file to be displayed. */

--- a/src/components/MISingleFileInput/index.ts
+++ b/src/components/MISingleFileInput/index.ts
@@ -1,0 +1,1 @@
+export * from './MISingleFileInput';

--- a/src/components/MISingleFileInput/utils.ts
+++ b/src/components/MISingleFileInput/utils.ts
@@ -1,6 +1,6 @@
 import { alpha, SxProps } from '@mui/system';
 import { theme } from '@theme';
-import { UploadStatus } from './MISingleFileInput';
+import { UploadStatus } from 'types/singleFileInput';
 
 function getDashedBorderStyle(color: string): SxProps {
   return {
@@ -17,45 +17,12 @@ function getDashedBorderStyle(color: string): SxProps {
 }
 
 /**
- * Truncate file name string if it is longer than 30 characters.
- * Keeps the file extension.
- *
- * @param fileName
- * @returns truncated file name
- */
-export const truncateFileName = (fileName: string) => {
-  const splittedFileName = fileName.split('.');
-  const fileExtension = splittedFileName[1];
-  const truncatedFileName = splittedFileName[0];
-  if (truncatedFileName.length >= 30) {
-    return `${truncatedFileName}... .${fileExtension ?? ''}`;
-  }
-  return fileName;
-};
-
-/**
- * Check if a mime type matches the set given in accept
- *
- * @link https://stackoverflow.com/a/66489392
- *
- * @param type the mime type to test, ex image/png
- * @param accept the mime types to accept, ex audio/*,video/*,image/png
- * @returns true if the mime is accepted, false otherwise
- */
-export function verifyAccept(type: string, accept?: Array<string>): boolean {
-  if (!accept) {
-    return true;
-  }
-  return accept.includes(type) || accept.includes(type.split('/')[0] + '/*');
-}
-
-/**
- * Returns the current status of the SingleFileInput based on his current state
+ * Returns the current status of the MISingleFileInput based on his current state
  *
  * @param file the current file
  * @param isLoading if the component is currently loading
  * @param isFileRejected if the file is rejected
- * @returns the current SingleFileInput status
+ * @returns the current MISingleFileInput status
  */
 export function getStatus(
   file: File | null,
@@ -89,7 +56,7 @@ export function getStatus(
 
 /**
  *
- * @param status the current status of the SingleFileInput
+ * @param status the current status of the MISingleFileInput
  * @returns the associated container styles
  */
 export function getContainerStyle(status: UploadStatus): SxProps {
@@ -134,16 +101,4 @@ export function getContainerStyle(status: UploadStatus): SxProps {
     default:
       return {};
   }
-}
-
-export function generateRandomID(): string {
-  /* eslint-disable no-bitwise */
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const randomNum =
-      typeof window !== 'undefined'
-        ? window.crypto.getRandomValues(new Uint8Array(1))[0] | 0
-        : (Math.random() * 16) | 0;
-    const v = c === 'x' ? randomNum : (randomNum & 0x3) | 0x8;
-    return v.toString(16);
-  });
 }

--- a/src/components/MISingleFileInput/utils.ts
+++ b/src/components/MISingleFileInput/utils.ts
@@ -1,0 +1,149 @@
+import { alpha, SxProps } from '@mui/system';
+import { theme } from '@theme';
+import { UploadStatus } from './MISingleFileInput';
+
+function getDashedBorderStyle(color: string): SxProps {
+  return {
+    border: '1px solid transparent',
+    backgroundImage:
+      `repeating-linear-gradient(90deg, ${color} 0 9px, transparent 9px 18px), ` +
+      `repeating-linear-gradient(180deg, ${color} 0 9px, transparent 9px 18px), ` +
+      `repeating-linear-gradient(90deg, ${color} 0 9px, transparent 9px 18px), ` +
+      `repeating-linear-gradient(180deg, ${color} 0 9px, transparent 9px 18px)`,
+    backgroundPosition: 'top left, top right, bottom left, top left',
+    backgroundSize: '100% 1px, 1px 100%, 100% 1px, 1px 100%',
+    backgroundRepeat: 'no-repeat',
+  };
+}
+
+/**
+ * Truncate file name string if it is longer than 30 characters.
+ * Keeps the file extension.
+ *
+ * @param fileName
+ * @returns truncated file name
+ */
+export const truncateFileName = (fileName: string) => {
+  const splittedFileName = fileName.split('.');
+  const fileExtension = splittedFileName[1];
+  const truncatedFileName = splittedFileName[0];
+  if (truncatedFileName.length >= 30) {
+    return `${truncatedFileName}... .${fileExtension ?? ''}`;
+  }
+  return fileName;
+};
+
+/**
+ * Check if a mime type matches the set given in accept
+ *
+ * @link https://stackoverflow.com/a/66489392
+ *
+ * @param type the mime type to test, ex image/png
+ * @param accept the mime types to accept, ex audio/*,video/*,image/png
+ * @returns true if the mime is accepted, false otherwise
+ */
+export function verifyAccept(type: string, accept?: Array<string>): boolean {
+  if (!accept) {
+    return true;
+  }
+  return accept.includes(type) || accept.includes(type.split('/')[0] + '/*');
+}
+
+/**
+ * Returns the current status of the SingleFileInput based on his current state
+ *
+ * @param file the current file
+ * @param isLoading if the component is currently loading
+ * @param isFileRejected if the file is rejected
+ * @returns the current SingleFileInput status
+ */
+export function getStatus(
+  file: File | null,
+  isLoading: boolean,
+  error: boolean,
+  isFileRejected: boolean,
+  isDragOver: boolean
+): UploadStatus {
+  if (error) {
+    return UploadStatus.ERROR;
+  }
+
+  if (isLoading) {
+    return UploadStatus.LOADING;
+  }
+
+  if (isFileRejected) {
+    return UploadStatus.REJECTED;
+  }
+
+  if (isDragOver) {
+    return UploadStatus.DRAG_OVER;
+  }
+
+  if (!file) {
+    return UploadStatus.IDLE;
+  }
+
+  return UploadStatus.SELECTED;
+}
+
+/**
+ *
+ * @param status the current status of the SingleFileInput
+ * @returns the associated container styles
+ */
+export function getContainerStyle(status: UploadStatus): SxProps {
+  switch (status) {
+    case UploadStatus.IDLE:
+      return {
+        ...getDashedBorderStyle(theme.colors.blue[300]),
+        backgroundColor: alpha(theme.colors.blue[500], 0.08),
+        '&:hover': {
+          backgroundColor: alpha(theme.colors.blue[500], 0.2),
+        },
+      };
+    case UploadStatus.DRAG_OVER:
+      return {
+        ...getDashedBorderStyle(theme.colors.blue[300]),
+        backgroundColor: alpha(theme.colors.blue[500], 0.18),
+      };
+    case UploadStatus.LOADING:
+      return {
+        border: '1px solid',
+        borderColor: theme.colors.neutral.grey[200],
+        backgroundColor: 'white',
+      };
+    case UploadStatus.REJECTED:
+      return {
+        border: '1px solid',
+        borderColor: theme.colors.error[400],
+        backgroundColor: theme.colors.error[100],
+      };
+    case UploadStatus.ERROR:
+      return {
+        ...getDashedBorderStyle(theme.colors.error[400]),
+        backgroundColor: theme.colors.error[100],
+      };
+    case UploadStatus.SELECTED:
+      return {
+        border: '1px solid',
+        borderColor: theme.colors.neutral.grey[100],
+        backgroundColor: 'white',
+        px: 3,
+      };
+    default:
+      return {};
+  }
+}
+
+export function generateRandomID(): string {
+  /* eslint-disable no-bitwise */
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const randomNum =
+      typeof window !== 'undefined'
+        ? window.crypto.getRandomValues(new Uint8Array(1))[0] | 0
+        : (Math.random() * 16) | 0;
+    const v = c === 'x' ? randomNum : (randomNum & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}

--- a/src/components/SingleFileInput/SingleFileInput.tsx
+++ b/src/components/SingleFileInput/SingleFileInput.tsx
@@ -14,15 +14,17 @@ import {
 } from '@mui/material';
 
 /* Icons */
-import AttachFileIcon from '@mui/icons-material/AttachFile';
-import CloseIcon from '@mui/icons-material/Close';
-import CloudUploadIcon from '@mui/icons-material/CloudUpload';
-import ErrorIcon from '@mui/icons-material/Error';
+import {
+  AttachFile as AttachFileIcon,
+  Close as CloseIcon,
+  CloudUpload as CloudUploadIcon,
+  Error as ErrorIcon,
+} from '@mui/icons-material';
 
 /* Utils */
-import { getContainerStyle, getColorStyle, getStatus } from './utils';
 import { UploadStatus } from 'types/singleFileInput';
 import { generateRandomID, verifyAccept, truncateFileName } from 'utils/singleFileInput';
+import { getColorStyle, getContainerStyle, getStatus } from './utils';
 
 export type SingleFileInputProps = {
   /** The file to be displayed. */
@@ -74,7 +76,6 @@ const OrientedBox = ({ vertical, children }: { vertical?: boolean; children: Rea
     display="flex"
     justifyContent="center"
     alignItems="center"
-    flexDirection={vertical ? 'column' : 'row'}
     flexDirection={vertical ? 'column' : 'row'}
     margin="auto"
     flex={1}

--- a/src/components/SingleFileInput/SingleFileInput.tsx
+++ b/src/components/SingleFileInput/SingleFileInput.tsx
@@ -1,5 +1,7 @@
 'use client';
+'use client';
 
+import { useRef, ChangeEvent, DragEvent, ReactNode, useState } from 'react';
 import {
   Box,
   Button,
@@ -10,25 +12,17 @@ import {
   LinearProgress,
   Typography,
 } from '@mui/material';
-import { ChangeEvent, DragEvent, ReactNode, useRef, useState } from 'react';
 
 /* Icons */
-import {
-  AttachFile as AttachFileIcon,
-  Close as CloseIcon,
-  CloudUpload as CloudUploadIcon,
-  Error as ErrorIcon,
-} from '@mui/icons-material';
+import AttachFileIcon from '@mui/icons-material/AttachFile';
+import CloseIcon from '@mui/icons-material/Close';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import ErrorIcon from '@mui/icons-material/Error';
 
 /* Utils */
-import {
-  generateRandomID,
-  getColorStyle,
-  getContainerStyle,
-  getStatus,
-  truncateFileName,
-  verifyAccept,
-} from './utils';
+import { getContainerStyle, getColorStyle, getStatus } from './utils';
+import { UploadStatus } from 'types/singleFileInput';
+import { generateRandomID, verifyAccept, truncateFileName } from 'utils/singleFileInput';
 
 export type SingleFileInputProps = {
   /** The file to be displayed. */
@@ -81,6 +75,7 @@ const OrientedBox = ({ vertical, children }: { vertical?: boolean; children: Rea
     justifyContent="center"
     alignItems="center"
     flexDirection={vertical ? 'column' : 'row'}
+    flexDirection={vertical ? 'column' : 'row'}
     margin="auto"
     flex={1}
     p={3}
@@ -88,14 +83,6 @@ const OrientedBox = ({ vertical, children }: { vertical?: boolean; children: Rea
     {children}
   </Box>
 );
-
-export enum UploadStatus {
-  IDLE = 'IDLE',
-  LOADING = 'LOADING',
-  REJECTED = 'REJECTED',
-  ERROR = 'ERROR',
-  SELECTED = 'SELECTED',
-}
 
 export const SingleFileInput = ({
   value,

--- a/src/components/SingleFileInput/utils.ts
+++ b/src/components/SingleFileInput/utils.ts
@@ -1,45 +1,6 @@
 import { alpha, SxProps } from '@mui/system';
 import { theme } from '@theme';
-import { UploadStatus } from './SingleFileInput';
-
-/**
- * Truncate file name string if it is longer than 30 characters.
- * Keeps the file extension.
- *
- * @param fileName
- * @returns truncated file name
- */
-export const truncateFileName = (fileName: string) => {
-  // a file name can have multiple dots, so we must take the last one
-  const lastDotIndex = fileName.lastIndexOf('.');
-  // file name without extension
-  if (lastDotIndex <= 0) {
-    return fileName.length >= 30 ? `${fileName.substring(0, 30)}...` : fileName;
-  }
-  // file name with extension
-  const namePart = fileName.substring(0, lastDotIndex);
-  const extensionPart = fileName.substring(lastDotIndex);
-  if (namePart.length >= 30) {
-    return `${namePart.substring(0, 30)}...${extensionPart}`;
-  }
-  return fileName;
-};
-
-/**
- * Check if a mime type matches the set given in accept
- *
- * @link https://stackoverflow.com/a/66489392
- *
- * @param type the mime type to test, ex image/png
- * @param accept the mime types to accept, ex audio/*,video/*,image/png
- * @returns true if the mime is accepted, false otherwise
- */
-export function verifyAccept(type: string, accept?: Array<string>): boolean {
-  if (!accept) {
-    return true;
-  }
-  return accept.includes(type) || accept.includes(type.split('/')[0] + '/*');
-}
+import { UploadStatus } from 'types/singleFileInput';
 
 /**
  * Returns the current status of the SingleFileInput based on his current state
@@ -121,16 +82,4 @@ export function getColorStyle(status: UploadStatus): 'primary' | 'error' {
     default:
       return 'primary';
   }
-}
-
-export function generateRandomID(): string {
-  /* eslint-disable no-bitwise */
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const randomNum =
-      typeof window !== 'undefined'
-        ? window.crypto.getRandomValues(new Uint8Array(1))[0] | 0
-        : (Math.random() * 16) | 0;
-    const v = c === 'x' ? randomNum : (randomNum & 0x3) | 0x8;
-    return v.toString(16);
-  });
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -45,3 +45,4 @@ export * from './MIPaper';
 export * from './MIBoxedModule';
 export * from './MIStepper';
 export * from './MIBreadcrumbs';
+export * from './MISingleFileInput';

--- a/src/types/singleFileInput.ts
+++ b/src/types/singleFileInput.ts
@@ -1,0 +1,8 @@
+export enum UploadStatus {
+  IDLE = 'IDLE',
+  DRAG_OVER = 'DRAG_OVER',
+  LOADING = 'LOADING',
+  REJECTED = 'REJECTED',
+  ERROR = 'ERROR',
+  SELECTED = 'SELECTED',
+}

--- a/src/utils/singleFileInput.ts
+++ b/src/utils/singleFileInput.ts
@@ -1,0 +1,44 @@
+/**
+ * Truncate file name string if it is longer than 30 characters.
+ * Keeps the file extension.
+ *
+ * @param fileName
+ * @returns truncated file name
+ */
+export const truncateFileName = (fileName: string) => {
+  const splittedFileName = fileName.split('.');
+  const fileExtension = splittedFileName[1];
+  const truncatedFileName = splittedFileName[0];
+  if (truncatedFileName.length >= 30) {
+    return `${truncatedFileName}... .${fileExtension ?? ''}`;
+  }
+  return fileName;
+};
+
+/**
+ * Check if a mime type matches the set given in accept
+ *
+ * @link https://stackoverflow.com/a/66489392
+ *
+ * @param type the mime type to test, ex image/png
+ * @param accept the mime types to accept, ex audio/*,video/*,image/png
+ * @returns true if the mime is accepted, false otherwise
+ */
+export function verifyAccept(type: string, accept?: Array<string>): boolean {
+  if (!accept) {
+    return true;
+  }
+  return accept.includes(type) || accept.includes(type.split('/')[0] + '/*');
+}
+
+export function generateRandomID(): string {
+  /* eslint-disable no-bitwise */
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const randomNum =
+      typeof window !== 'undefined'
+        ? window.crypto.getRandomValues(new Uint8Array(1))[0] | 0
+        : (Math.random() * 16) | 0;
+    const v = c === 'x' ? randomNum : (randomNum & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}

--- a/src/utils/singleFileInput.ts
+++ b/src/utils/singleFileInput.ts
@@ -1,16 +1,15 @@
-/**
- * Truncate file name string if it is longer than 30 characters.
- * Keeps the file extension.
- *
- * @param fileName
- * @returns truncated file name
- */
 export const truncateFileName = (fileName: string) => {
-  const splittedFileName = fileName.split('.');
-  const fileExtension = splittedFileName[1];
-  const truncatedFileName = splittedFileName[0];
-  if (truncatedFileName.length >= 30) {
-    return `${truncatedFileName}... .${fileExtension ?? ''}`;
+  // a file name can have multiple dots, so we must take the last one
+  const lastDotIndex = fileName.lastIndexOf('.');
+  // file name without extension
+  if (lastDotIndex <= 0) {
+    return fileName.length >= 30 ? `${fileName.substring(0, 30)}...` : fileName;
+  }
+  // file name with extension
+  const namePart = fileName.substring(0, lastDotIndex);
+  const extensionPart = fileName.substring(lastDotIndex);
+  if (namePart.length >= 30) {
+    return `${namePart.substring(0, 30)}...${extensionPart}`;
   }
   return fileName;
 };


### PR DESCRIPTION
## Short description
This pull request introduces the new `MISingleFileInput` component, including its documentation, Storybook stories, and utility functions, and refactors file input utilities for better code reuse and maintainability. It also standardizes the `UploadStatus` enum usage across components and improves background handling in Storybook for visual consistency.

- Added the new `MISingleFileInput` component with comprehensive documentation (`.mdx`) and Storybook stories demonstrating all visual and behavioral states. This component supports drag-and-drop file upload, error handling, loading state, file preview, and accessibility best practices. 

- Introduced and used a shared `UploadStatus` enum in `src/types/singleFileInput.ts`, now referenced by both file input components and their utilities for consistent status handling, including the addition of the `DRAG_OVER` status. 

- Improved Storybook backgrounds by adding a `white` background option to ensure accurate visual testing of the new file input component.
