### PR TITLE
refactor(TS): added Palette on muiOverrides.d

### DIFF
--- a/src/theme/foundations/palette.ts
+++ b/src/theme/foundations/palette.ts
@@ -120,54 +120,6 @@ export const palette = {
   },
 } as const;
 
-declare module '@mui/material/styles' {
-  interface Palette {
-    pagoPA: Palette['primary'];
-    europeanUnion: Palette['primary'];
-    checkIban: Palette['primary'];
-    extraLight: Palette['warning'];
-    primaryAction: Palette['action'];
-    primaryContained: PrimaryContainedPalette;
-    shadow: ShadowPalette;
-    backdrop: BackgroundPalette;
-    menuItem: BackgroundPalette;
-    decorativeIcon?: string;
-    negative: SimplePaletteColorOptions;
-    indigo: Palette['primary'];
-  }
+// declare module '@mui/material/styles' {
 
-  type PrimaryContainedPalette = {
-    hover: string;
-  };
-
-  type ShadowPalette = {
-    main: string;
-  };
-
-  type BackgroundPalette = {
-    background: string;
-  };
-
-  interface PaletteOptions {
-    pagoPA?: PaletteOptions['primary'];
-    europeanUnion?: PaletteOptions['primary'];
-    checkIban?: PaletteOptions['primary'];
-    extraLight?: PaletteOptions['warning'];
-    primaryAction?: PaletteOptions['action'];
-    negative?: SimplePaletteColorOptions;
-    indigo?: SimplePaletteColorOptions;
-  }
-
-  interface PaletteColor {
-    extraLight?: string;
-    100: string;
-    850: string;
-  }
-
-  interface SimplePaletteColorOptions {
-    dark?: string;
-    light?: string;
-    contrastText?: string;
-    extraLight?: string;
-  }
-}
+// }

--- a/src/theme/foundations/palette.ts
+++ b/src/theme/foundations/palette.ts
@@ -119,7 +119,3 @@ export const palette = {
     850: '#614C15',
   },
 } as const;
-
-// declare module '@mui/material/styles' {
-
-// }

--- a/src/types/muiOverrides.d.ts
+++ b/src/types/muiOverrides.d.ts
@@ -15,6 +15,56 @@ declare module '@mui/material/styles' {
   interface Theme {
     colors: typeof colors;
   }
+
+    interface Palette {
+    pagoPA: Palette['primary'];
+    europeanUnion: Palette['primary'];
+    checkIban: Palette['primary'];
+    extraLight: Palette['warning'];
+    primaryAction: Palette['action'];
+    primaryContained: PrimaryContainedPalette;
+    shadow: ShadowPalette;
+    backdrop: BackgroundPalette;
+    menuItem: BackgroundPalette;
+    decorativeIcon?: string;
+    negative: SimplePaletteColorOptions;
+    indigo: Palette['primary'];
+  }
+
+  type PrimaryContainedPalette = {
+    hover: string;
+  };
+
+  type ShadowPalette = {
+    main: string;
+  };
+
+  type BackgroundPalette = {
+    background: string;
+  };
+
+  interface PaletteOptions {
+    pagoPA?: PaletteOptions['primary'];
+    europeanUnion?: PaletteOptions['primary'];
+    checkIban?: PaletteOptions['primary'];
+    extraLight?: PaletteOptions['warning'];
+    primaryAction?: PaletteOptions['action'];
+    negative?: SimplePaletteColorOptions;
+    indigo?: SimplePaletteColorOptions;
+  }
+
+  interface PaletteColor {
+    extraLight?: string;
+    100: string;
+    850: string;
+  }
+
+  interface SimplePaletteColorOptions {
+    dark?: string;
+    light?: string;
+    contrastText?: string;
+    extraLight?: string;
+  }
 }
 
 declare module '@mui/system' {


### PR DESCRIPTION
## 📝 Description

This PR fixes and clarifies MUI theme type augmentation placement.

The main goal is to keep runtime theme definitions separated from TypeScript module augmentation, so theme values and type declarations are maintained in the right files and are easier to evolve safely.

## 🛠 List of changes
Removed leftover commented augmentation block from `palette.ts`
Consolidated/customized MUI theme augmentation in `muiOverrides.d.ts,` including custom palette keys used by the design system (for example: pagoPA, europeanUnion, checkIban, primaryAction, primaryContained, shadow, backdrop, menuItem, indigo, and extra palette shades).

## 🎯 Why
Improves separation of concerns between runtime theme config and TypeScript typing.
Makes custom palette typing easier to find and maintain in a single augmentation file.
Reduces risk of duplicated or drifting declarations across theme files.
